### PR TITLE
Fix userscript ↔ GitHub Pages linking for Violentmonkey installs

### DIFF
--- a/bit.user.js
+++ b/bit.user.js
@@ -81,7 +81,7 @@ Code below this point runs on any site, including the GUI.
 
 const backendConfig = {
     'hosts': { 'prod': 'bitbytelabs.github.io', 'dev': 'localhost' },
-    'path': '/bit/'
+    'path': '/Bit/app/'
 };
 
 const currentBackendUrlKey = 'currentBackendURL';

--- a/index.html
+++ b/index.html
@@ -34,11 +34,7 @@
                 <a href="faq/" aria-label="Frequently Asked Questions" class="fancy-btn"><i class="bi bi-chat-square-quote"></i>FAQ</a>
                 <a href="blog/" aria-label="View Bit blog" class="fancy-btn"><i class="bi bi-pen"></i>Blog</a>
                 <a href="contributing/" aria-label="Contribute to Bit" class="fancy-btn"><i class="bi bi-heart"></i></a>
-<<<<<<< HEAD
                 <a href="https://github.com/bitbytelabs/Bit" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
-=======
-                <a href="https://github.com/psyyke/Bit" target="_blank" class="github-corner fancy-btn" aria-label="View source on Github"><i class="bi bi-github"></i></a>
->>>>>>> 74e1161a55318483985827e66e8e15e8a9d7464f
             </div>
         </header>
         <section class="content">
@@ -97,11 +93,7 @@
                     <img style="right: -42px;width: 90px;bottom: -20px;transform: rotate(6deg);" class="floaty-piece floaty0" src="assets/images/pieces/staunty/bB.svg"/>
                 </section>
                 <section>
-<<<<<<< HEAD
                     <p><b>Bit</b> (<i>Bit Byte Labs</i>) is an open-source chess assistant (not a chess cheat), designed to help you make better moves using a chess engine. Just install the userscript, open the Bit GUI, and you're ready to go—no downloads necessary!</p>
-=======
-                    <p><b>Bit</b> (<i>Advanced Chess Assistance System</i>) is an open-source chess assistant (not a chess cheat), designed to help you make better moves using a chess engine. Just install the userscript, open the Bit GUI, and you're ready to go—no downloads necessary!</p>
->>>>>>> 74e1161a55318483985827e66e8e15e8a9d7464f
                     <ul>
                         <li><strong>Completely free</strong> and <strong>open source</strong>! (Licensed with GPLv3 💖)</li>
                         <li>Lots of built-in WASM engines: Stockfish, Lc0, Maia and more...</li>
@@ -116,7 +108,7 @@
                         <thead>
                             <tr>
                                 <th class="bordered tweaking"><a href="app/">▶️ Open Bit</a></th>
-                                <th class="bordered fancy-btn"><a href="acas.user.js">⬇️ Download (Direct)</a></th>
+                                <th class="bordered fancy-btn"><a href="bit.user.js">⬇️ Install Userscript</a></th>
                                 <th class="bordered fancy-btn"><a href="https://github.com/bitbytelabs/bit/issues" target="_blank" rel="noopener">💬 Discuss With Community</a></th>
                             </tr>
                         </thead>

--- a/install/index.html
+++ b/install/index.html
@@ -59,7 +59,7 @@
                             </ul>
                         </li>
                         <li>
-                            Install Bit from <a href="https://github.com/bitbytelabs/Bit" target="_blank" rel="noopener">Github</a>. You can also manually create a new userscript on the manager and then copy paste the code from <code>acas.user.js</code> there.
+                            Install Bit directly by opening <a href="../bit.user.js" target="_blank" rel="noopener"><code>bit.user.js</code></a> in your userscript manager (Violentmonkey/Tampermonkey). You can also get it from <a href="https://github.com/bitbytelabs/Bit" target="_blank" rel="noopener">Github</a> and paste it manually if needed.
                         </li>
                         <li>
                             Open the <a target="_about" href="../app">GUI</a>. Follow the instructions.


### PR DESCRIPTION
### Motivation

- Make the userscript and the GitHub Pages GUI work together when installed via Violentmonkey/Tampermonkey by using the correct GitHub Pages path and a real userscript filename on the site.
- Provide a one‑click install flow and clear install docs so users can open `bit.user.js` directly in a userscript manager.
- Remove leftover merge noise in the homepage while touching the same area.

### Description

- Updated the userscript backend path in `bit.user.js` by changing `backendConfig.path` to `'/Bit/app/'` so the GUI detection logic matches the deployed GitHub Pages route. (file: `bit.user.js`)
- Replaced the homepage direct-download link to point at `bit.user.js` (Install Userscript) instead of the non-existent `acas.user.js`. (file: `index.html`)
- Clarified the install instructions to recommend opening `bit.user.js` in the userscript manager (Violentmonkey/Tampermonkey) for one‑click installation. (file: `install/index.html`)
- Cleaned up residual merge markers in `index.html` encountered while editing the install link area. (file: `index.html`)

### Testing

- Ran `node --check bit.user.js` and `node --check index.js` to validate JS syntax; both checks passed.
- Searched for unresolved merge markers with `rg -n "<<<<<<<|>>>>>>>|=====" index.html install/index.html bit.user.js` and confirmed no occurrences remained.
- Executed a small Node snippet to validate the backend detection logic for `'/Bit/app/'` (returns `true`) and the old `'/bit/'` (returns `false`), and it behaved as expected.
- Served the site locally with `python3 -m http.server 8000 --directory /workspace/Bit` and captured a screenshot of `/install/` for visual verification; the served page rendered with the updated install link.

All automated checks and local validations completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_698d8126917c8332a733c55b0f64f3f4)