### PR TITLE
Potential fix for code scanning alert no. 38: Missing origin verification in `postMessage` handler

### DIFF
--- a/app/assets/engines/lila-stockfish/fsf14.js
+++ b/app/assets/engines/lila-stockfish/fsf14.js
@@ -133,7 +133,25 @@ var Fsf14Web = (() => {
                             return;
                         }
                         let f = [];
-                        self.onmessage = (g) => f.push(g);
+                        self.onmessage = (g) => {
+                            // Basic validation of incoming message before queuing
+                            if (!g || typeof g !== "object" || typeof g.data !== "object" || g.data === null) {
+                                q && q("worker: received malformed message event (pre-start)");
+                                return;
+                            }
+                            const msg = g.data;
+                            const cmd = msg.ka;
+                            const allowedCommands = { load: !0, run: !0, checkMailbox: !0 };
+                            if (!cmd && msg.target === "setimmediate") {
+                                // Allow internal setImmediate messages
+                                f.push(g);
+                            } else if (cmd && allowedCommands[cmd]) {
+                                f.push(g);
+                            } else {
+                                q && q(`worker: rejected unexpected command ${String(cmd)} (pre-start)`);
+                                q && q(msg);
+                            }
+                        };
                         self.startWorker = () => {
                             postMessage({ ka: "loaded" });
                             for (let g of f) b(g);


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/38](https://github.com/bitbytelabs/Bit/security/code-scanning/38)

In general, to fix missing origin verification in a `postMessage` handler, you either: (a) check `event.origin`/`event.source` against a whitelist of trusted origins/senders, or (b) implement an explicit application-level trust mechanism (shared secret token, capability IDs, etc.) and reject messages that don’t satisfy it. In a worker, `event.origin` is often `''` or the page origin, and security is usually enforced by who can obtain the worker reference. Since we can’t change how the worker is constructed, the best low-impact fix is to add a simple validation check on the incoming event object before queuing or processing it, and reject events that don’t have the expected structure and (optionally) a project-defined trust marker.

Concretely here, we already have a structural validation at the top of function `b(c)` (it checks `c.data`, `d.ka`, allowed commands, etc.). The offending `self.onmessage = (g) => f.push(g);` temporarily queues messages and later replays them by calling `b(g)`. To ensure *all* messages, including queued ones, undergo the same validation, we should:

1. Introduce a small helper (or inline logic) to verify an event is acceptable *before* pushing it into `f`. At minimum, ensure `g` is an object and `g.data` is an object with a known command (`ka`) or a recognized `target`. Optionally, if the broader app uses an application-level origin marker (e.g. `data.origin` or `data.source`), we could check that as well, but we can’t assume that here.
2. Reuse the same validation logic already in `b` so we don’t change behavior for valid messages, while preventing malformed or unexpected ones from even being queued.
3. Keep all changes localized to the snippet: only edit the `self.onmessage = (g) => f.push(g);` section and, if needed, add a short inline conditional, avoiding any new imports or large refactors.

This preserves existing functionality for legitimate messages but ensures that clearly invalid or unexpected messages, including during the “pre-startWorker” phase, are ignored rather than trusted blindly.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
