### PR TITLE
fix: update picture-in-picture title branding

### DIFF
--- a/assets/js/bit-backend-gui-pip.js
+++ b/assets/js/bit-backend-gui-pip.js
@@ -129,7 +129,7 @@ async function refreshPipView() {
     // Header title
     ctxQueue.push(['fillStyle', 'white']);
     ctxQueue.push(['font', `800 ${pipFontSizes.medium}px Mona Sans`]);
-    ctxQueue.push(['fillText', ['A.C.A.S', 12, 32]]);
+    ctxQueue.push(['fillText', ['Bit', 12, 32]]);
 
     // Subtext font
     ctxQueue.push(['fillStyle', 'rgba(255, 255, 255, 0.7)']);


### PR DESCRIPTION
### Motivation
- Align the Picture-in-Picture header label with the current app branding by replacing the legacy `A.C.A.S` label with `Bit` in the PiP renderer.

### Description
- Updated the PiP canvas header text in `assets/js/bit-backend-gui-pip.js` by changing the `fillText` call from `['A.C.A.S', 12, 32]` to `['Bit', 12, 32]`.

### Testing
- Ran `node --check assets/js/bit-backend-gui-pip.js` which completed without errors.
- Served the app locally with `python3 -m http.server 4173 --directory /workspace/Bit` and captured a UI screenshot with Playwright to validate the rendered header, which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699002ff1e24833287fc5b4c946e0003)