### PR TITLE
Potential fix for code scanning alert no. 44: Missing origin verification in `postMessage` handler

### DIFF
--- a/app/assets/engines/lila-stockfish/sf171-79.js
+++ b/app/assets/engines/lila-stockfish/sf171-79.js
@@ -110,8 +110,19 @@ var Sf17179Web = (() => {
             };
             function b(c) {
                 try {
-                    var d = c.data,
-                        e = d.la;
+                    // Basic validation of incoming message event before using its data.
+                    if (!c || typeof c !== "object") return;
+                    // In workers, c.data is typically the payload; ensure it is an object.
+                    var d = c.data;
+                    if (!d || (typeof d !== "object" && typeof d !== "function")) return;
+                    var e = d.la;
+                    if (typeof e !== "string") return;
+                    // If an origin property exists (e.g. when used in a window context),
+                    // perform a minimal sanity check. We avoid hardcoding a specific origin
+                    // to prevent breaking existing valid callers but ignore clearly invalid ones.
+                    if ("origin" in c && typeof c.origin === "string") {
+                        if (!c.origin || c.origin === "null") return;
+                    }
                     if ("load" === e) {
                         let f = [];
                         self.onmessage = (g) => f.push(g);


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/44](https://github.com/bitbytelabs/Bit/security/code-scanning/44)

In general, to fix missing origin verification or equivalent trust checks in a `postMessage`/`onmessage` handler, you either: (1) verify that the message comes from an expected origin or source, when `origin` is available (e.g., on `window` message events), and/or (2) strictly validate the structure and allowed values of the message before acting on it, discarding anything unexpected. In a worker context where `origin` may not be meaningful, strong structural and command validation is the practical way to mitigate misuse.

For this specific code, the risky handler is the temporary `self.onmessage = (g) => f.push(g);` inside the `"load"` branch, and the main handler function `b(c)` that consumes `c.data`. We should make `b` defensive by ensuring that `c.data` is an object with a known `la` command and only then proceeding. We can also add a lightweight origin check that only runs if `c` has an `origin` property (for compatibility between window and worker cases), but we must not hardcode a specific origin because that might change behavior. Instead, we can require that either `origin` is absent (worker-style messages) or that, when present, it is in an allowlist derived from `moduleArg` (if available) or at least not empty; given the constraint to avoid changing functionality, the safest non-breaking approach is to reject messages that clearly do not conform to the expected protocol while allowing all currently-valid messages.

Concretely, we will:
- Update `function b(c)` so that it:
  - Immediately returns (or logs and returns) if `c` is falsy, `c.data` is not an object, or `c.data.la` is missing or not a string.
  - Optionally checks for `c.origin` and, if present, ignores the message if `c.origin === "null"` (a common pattern for opaque origins) or is an obviously invalid type. This adds some basic origin hardening without changing normal legitimate flows that likely have a normal origin or no origin at all in worker messages.
- Keep the rest of the logic intact so behavior for valid messages is unchanged.
- Leave the `self.onmessage = (g) => f.push(g);` as a simple queue, but since all messages go through `b(g)`, they will now be validated before being processed.

All changes are within `app/assets/engines/lila-stockfish/sf171-79.js`, only in the shown region defining `function b(c)`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
