### PR TITLE
fix: harden userscript postMessage bridge

### DIFF
--- a/assets/js/bit-userscript-bridge.js
+++ b/assets/js/bit-userscript-bridge.js
@@ -1,10 +1,14 @@
 function messageUserscript(type, args = []) {
     return new Promise((resolve, reject) => {
+        const messageOrigin = window.location.origin;
         const messageId = getUniqueID();
         let timeoutId;
 
         const listener = (event) => {
-            if(event.data.messageId === messageId && event.data.sender !== 'GUI') {
+            if(event.source === window
+                && event.origin === messageOrigin
+                && event.data?.sender === 'USERSCRIPT'
+                && event.data.messageId === messageId) {
                 clearTimeout(timeoutId);
                 window.removeEventListener('message', listener);
 
@@ -25,7 +29,7 @@ function messageUserscript(type, args = []) {
             type,
             messageId,
             args
-        }, '*');
+        }, messageOrigin);
     });
 }
 
@@ -63,7 +67,7 @@ if(typeof window?.USERSCRIPT !== 'object') {
                 type: 'USERSCRIPT_setValue',
                 messageId: null,
                 args: [key, value]
-            }, '*');
+            }, window.location.origin);
         }
     };
 } else {


### PR DESCRIPTION
### Motivation
- Prevent untrusted cross-window messages from being processed by replacing wildcard `postMessage(..., '*')` usage with same-origin targets and explicit senders.
- Reduce the attack surface for the userscript↔GUI bridge by ensuring only expected messages from the same window and origin are handled.

### Description
- Replaced wildcard `postMessage(..., '*')` with `window.location.origin` when sending responses from the userscript in `bit.user.js`.
- Tagged responses from the userscript with `sender: 'USERSCRIPT'` and updated GUI-side listeners to only accept messages with that sender in `assets/js/bit-userscript-bridge.js`.
- Added inbound validation checks (`event.source === window`, `event.origin === messageOrigin`, and `event.data?.sender === 'GUI'` / `'USERSCRIPT'`) before dispatching handlers.
- Aligned non-async `setValue` outgoing `postMessage` to target `window.location.origin` as well.

### Testing
- Ran syntax checks with `node --check bit.user.js` which completed successfully.
- Ran syntax checks with `node --check assets/js/bit-userscript-bridge.js` which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900b6b2c208332ad3493b66efc89eb)