### PR TITLE
feat: add community health documentation

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,67 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in our
+community a harassment-free experience for everyone, regardless of age,
+body size, visible or invisible disability, ethnicity, sex
+characteristics, gender identity and expression, level of experience,
+education, socio-economic status, nationality, personal appearance,
+race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open,
+welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment include:
+
+- Demonstrating empathy and kindness toward other people.
+- Being respectful of differing opinions, viewpoints, and experiences.
+- Giving and gracefully accepting constructive feedback.
+- Accepting responsibility and apologizing to those affected by our mistakes.
+- Focusing on what is best for the overall community.
+
+Examples of unacceptable behavior include:
+
+- The use of sexualized language or imagery, and sexual attention or
+advances of any kind.
+- Trolling, insulting or derogatory comments, and personal or political
+attacks.
+- Public or private harassment.
+- Publishing others' private information, such as a physical or email
+address, without their explicit permission.
+- Any other conduct that could reasonably be considered inappropriate in
+a professional setting.
+
+## Enforcement Responsibilities
+
+Community leaders are responsible for clarifying and enforcing our
+standards of acceptable behavior. They will take appropriate and fair
+corrective action in response to behavior they deem inappropriate,
+threatening, offensive, or harmful.
+
+Community leaders have the right and responsibility to remove, edit, or
+reject comments, commits, code, wiki edits, issues, and other
+contributions that are not aligned to this Code of Conduct and will
+communicate reasons for moderation decisions when appropriate.
+
+## Scope
+
+This Code of Conduct applies within all community spaces and also
+applies when an individual is officially representing the project in
+public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may
+be reported by opening a private security advisory or contacting the
+maintainers via GitHub Discussions.
+
+All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the
+[Contributor Covenant](https://www.contributor-covenant.org), version
+2.1.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -1,0 +1,63 @@
+# Contributing to Bit
+
+Thanks for your interest in contributing to Bit! We welcome bug
+reports, fixes, features, and documentation improvements.
+
+## Before you start
+
+- Read the [Code of Conduct](./CODE_OF_CONDUCT.md).
+- Search existing issues and discussions before creating a new one.
+- Keep changes focused and scoped to a clear problem.
+
+## Development setup
+
+1. Fork and clone the repository.
+2. Create a branch from `main`.
+3. Make your changes.
+4. Test your changes locally.
+5. Commit using Conventional Commits.
+
+## Commit message format (required)
+
+This repository uses release automation, so commit messages must follow this format:
+
+- `fix: something` → patch release (`1.5.3` → `1.5.4`)
+- `feat: something` → minor release (`1.5.3` → `1.6.0`)
+- `feat!: breaking` → major release (`1.5.3` → `2.0.0`)
+
+Examples:
+
+- `fix: correct typo`
+- `feat: add login system`
+- `feat!: change API structure`
+
+## Pull requests
+
+When opening a pull request:
+
+- Explain **what** changed and **why**.
+- Link related issues.
+- Include screenshots for UI changes.
+- Keep PRs small and reviewable.
+- Ensure checks pass before requesting review.
+
+## Reporting bugs
+
+Please include:
+
+- Steps to reproduce.
+- Expected behavior.
+- Actual behavior.
+- Environment details (OS, browser, userscript manager, chess site/variant).
+- Console errors/screenshots when possible.
+
+## Suggesting features
+
+Feature requests should describe:
+
+- The problem being solved.
+- Why existing behavior is insufficient.
+- Proposed behavior.
+- Possible alternatives.
+
+Thank you for helping improve Bit.

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,43 @@
+# Security Policy
+
+## Supported Versions
+
+Security updates are provided for the latest `main` branch and the most recent release.
+
+| Version | Supported |
+| ------- | --------- |
+| Latest release | ✅ |
+| `main` branch | ✅ |
+| Older releases | ❌ |
+
+## Reporting a Vulnerability
+
+If you discover a security vulnerability, please report it privately and
+**do not** open a public issue.
+
+### Preferred method
+
+1. Go to this repository's **Security** tab.
+2. Click **Report a vulnerability** and submit a private advisory.
+
+### Alternative method
+
+If private advisories are unavailable, open a GitHub Discussion and
+include only minimal details while asking maintainers for a secure
+channel.
+
+## What to include in your report
+
+- A clear description of the issue.
+- Steps to reproduce.
+- Affected files/components.
+- Potential impact.
+- Any proof-of-concept details (if safe to share).
+
+## Response expectations
+
+- Initial acknowledgment: within 7 days.
+- Status updates: as work progresses.
+- Fix timeline: depends on severity and complexity.
+
+We appreciate responsible disclosure and will credit reporters when appropriate.


### PR DESCRIPTION
### Motivation

- Provide clear community guidelines to encourage respectful collaboration and set enforcement expectations.  
- Offer a private vulnerability reporting workflow and supported-version policy to improve security handling.  
- Standardize contribution workflow and commit message format to integrate with the repo's release automation.

### Description

- Add `CODE_OF_CONDUCT.md` adapted from Contributor Covenant 2.1 to define expected behavior, unacceptable conduct, scope, and enforcement responsibilities.  
- Add `SECURITY.md` that declares supported versions, describes a preferred private vulnerability reporting path via the repository Security tab, lists information to include in reports, and sets response expectations.  
- Add `CONTRIBUTING.md` with development setup steps, PR guidelines, bug/feature reporting templates, and required Conventional Commit examples (`fix:`, `feat:`, `feat!:`) compatible with release automation.  
- Ensure all three files are linted and formatted for Markdown style guidelines.

### Testing

- Ran `npx --yes markdownlint-cli2 CODE_OF_CONDUCT.md SECURITY.md CONTRIBUTING.md`, observed initial line-length errors, applied automated wrapping, and re-ran the same command to validate with `0 error(s)`.  
- Verified file contents via programmatic checks (file reads) to confirm the expected sections and examples are present.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69900ed534bc833296b68e9c4233381a)