### PR TITLE
Potential fix for code scanning alert no. 42: Missing origin verification in `postMessage` handler

### DIFF
--- a/app/assets/engines/lila-stockfish/sf17-79.js
+++ b/app/assets/engines/lila-stockfish/sf17-79.js
@@ -108,6 +108,15 @@ var Sf1779Web = (() => {
             self.onunhandledrejection = (c) => {
                 throw c.reason || c;
             };
+            function isTrustedMessage(event) {
+                if (!event || !event.data) return !1;
+                var data = event.data;
+                var cmd = data.la;
+                if (!data || "object" != typeof data || "string" != typeof cmd) return !1;
+                const Ra = new Set(["load", "run", "checkMailbox", "setimmediate"]);
+                if (!Ra.has(cmd) && data.target !== "setimmediate") return !1;
+                return !0;
+            }
             function b(c) {
                 try {
                     var d = c.data,
@@ -123,7 +132,10 @@ var Sf1779Web = (() => {
                     }
                     if ("load" === e) {
                         let f = [];
-                        self.onmessage = (g) => f.push(g);
+                        self.onmessage = (g) => {
+                            if (isTrustedMessage(g)) f.push(g);
+                            else q && q("worker: received untrusted or malformed message during load", g && g.data);
+                        };
                         self.startWorker = () => {
                             postMessage({ la: "loaded" });
                             for (let g of f) b(g);


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/42](https://github.com/bitbytelabs/Bit/security/code-scanning/42)

In general, to fix missing origin verification in a `postMessage`/`message` handler, you should ensure that each incoming `MessageEvent` is validated before being processed: check `event.origin` or `event.source` (in Workers, typically `event.origin` and possibly `event.currentTarget`/`self`) against an allowlist of trusted origins or a clear internal protocol. Only if the origin (or other trust property) matches expectations should the message data be processed.

In this specific snippet, the insecure part is the temporary handler:

```js
self.onmessage = (g) => f.push(g);
```

which unconditionally queues any incoming message event, and then `self.startWorker` later replays them through the main handler `b`:

```js
for (let g of f) b(g);
self.onmessage = b;
```

The main handler `b(c)` is where the actual protocol validation occurs, but during the initial loading phase, messages are simply stored. To avoid processing untrusted messages, we should add a small validation helper and use it both when queuing messages and (optionally) as a guard at the start of `b`. Since this is a generic library file and we cannot assume specific host origins, the safest minimal fix that preserves existing behavior is to ensure that only messages that meet the existing structural/protocol expectations are queued. That means checking that `g` is a `MessageEvent`-like object with a `data` field that is an object containing the expected `la` command string and that the command is among the allowed set, before adding it to `f`. This way, random `postMessage` calls from external origins that don't follow the internal protocol will be ignored early, including during the bootstrap phase.

Concretely:

- Inside the `if (l) { ... }` block where `b` is defined, add a small helper function `isTrustedMessage(event)` that checks `event` and `event.data` have the expected shape and that the command is in the allowed set (`["load", "run", "checkMailbox", "setimmediate"]`), mirroring the logic already in `b`.
- Update `self.onmessage = (g) => f.push(g);` to something like:

  ```js
  self.onmessage = (g) => {
      if (isTrustedMessage(g)) f.push(g);
      else q && q("worker: received untrusted or malformed message during load", g?.data);
  };
  ```

- Optionally, use the same helper at the very beginning of `b(c)` as a defensive check, to avoid duplicating the validation logic; but the key required change for the flagged line is to stop blindly queueing all messages.

No new imports or external libraries are needed; this is all internal JavaScript logic inside `app/assets/engines/lila-stockfish/sf17-79.js`.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
