### PR TITLE
Potential fix for code scanning alert no. 4: Useless regular-expression character escape

### DIFF
--- a/assets/libraries/chess.js/chess.js
+++ b/assets/libraries/chess.js/chess.js
@@ -1724,7 +1724,7 @@ export const Chess = function (fen) {
         .replace(header_string, '')
         .replace(
           /* encode comments so they don't get deleted below */
-          new RegExp(`(\{[^}]*\})+?|;([^${mask(newline_char)}]*)`, 'g'),
+          new RegExp(`(\\{[^}]*\\})+?|;([^${mask(newline_char)}]*)`, 'g'),
           function (match, bracket, semicolon) {
             return bracket !== undefined
               ? encode_comment(bracket)


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/4](https://github.com/bitbytelabs/Bit/security/code-scanning/4)

In general, when building regexes from strings, characters that are meant to be literals but are regex metacharacters (`{`, `}`, `[`, `]`, `(`, `)`, `\`, `+`, `*`, `?`, `.`, `|`, `^`, `$`) must be escaped at the regex level. Because backslashes are also the JS string escape character, in a normal string literal or template literal passed to `RegExp`, you usually need to double-escape: once for the JS string, once for the regex.

In this file, the problematic code is on line 1727:

```js
new RegExp(`(\{[^}]*\})+?|;([^${mask(newline_char)}]*)`, 'g'),
```

In a template literal, `\{` and `\}` are not special, so they evaluate to `{` and `}`. The resulting regex is `({[^}]*})+?|;(...)`. To ensure the opening and closing braces are treated as literal characters in the regex, we should escape `{` and `}` in the regex itself. Within a template literal, that requires writing `\\{` and `\\}` so that the resulting pattern contains `\{` and `\}`. The `[^}]*` part is already correct because `}` is not special inside a character class and does not need escaping. No imports or new helpers are needed; we just adjust the string inside `new RegExp` at that line.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
