### PR TITLE
Potential fix for code scanning alert no. 45: Missing origin verification in `postMessage` handler

### DIFF
--- a/app/assets/engines/zerofish/zerofishEngine.worker.js
+++ b/app/assets/engines/zerofish/zerofishEngine.worker.js
@@ -28,6 +28,20 @@ self.onunhandledrejection = e => {
 };
 
 function handleMessage(e) {
+  // Verify message origin when available to avoid processing messages
+  // from unexpected sources.
+  if (typeof e.origin !== "undefined" && e.origin) {
+    // In a worker, self.location.origin represents the expected origin.
+    var expectedOrigin = (typeof self.location !== "undefined" && self.location && self.location.origin)
+      ? self.location.origin
+      : null;
+
+    if (expectedOrigin && e.origin !== expectedOrigin) {
+      err && err(`Ignored message from unexpected origin: ${e.origin}`);
+      return;
+    }
+  }
+
   try {
     if(e.data.cmd === "load") {
       const messageQueue = [];


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/45](https://github.com/bitbytelabs/Bit/security/code-scanning/45)

In general, to fix this class of problem you ensure that any `message`/`onmessage` handler validates the sender before acting on the message. For browser contexts, that usually means checking `event.origin` against a whitelist of allowed origins (or using a configuration-driven list), and optionally checking `event.source` to ensure the message came from an expected window/worker. Messages from unexpected origins should be ignored or cause an error, and no sensitive behavior should be triggered for them.

For this specific file, we can add a small origin-validation step at the top of `handleMessage(e)`. Because this is running in a worker, `e` is a `MessageEvent`. We will:

1. Derive a list of allowed origins. With minimal assumptions and without changing behavior for normal same-origin use, we can consider:
   - The current origin (`self.location.origin`) when available.
   - Possibly `null`/`"null"`/`""` if this is loaded from a file URL or some CSP-restricted context.
   However, the safest general-purpose change that’s still functional is to:
   - Allow messages when `e.origin` is falsy (covers worker-internal or non-window senders, where the browser often leaves `origin` empty).
   - Or when it matches `self.location.origin` if available.
2. If the origin check fails, log an error and return early before any handling of `e.data` occurs.

Since we can’t introduce configuration plumbing or change how the worker is instantiated, this approach is conservative and is unlikely to break existing same-origin usage, while preventing messages from clearly different origins (where `e.origin` is set and differs from `self.location.origin`). We only need to modify `handleMessage` inside `app/assets/engines/zerofish/zerofishEngine.worker.js`; no new imports or external libraries are required.

Concretely:
- Insert a few lines near the top of `handleMessage(e)` (right after the opening brace and before `try {`) to compute `allowedOrigin` from `self.location.origin` (if defined) and compare it to `e.origin` when `e.origin` is present.
- If `e.origin` is present and different from `allowedOrigin`, log and `return` without processing the message.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
