### PR TITLE
feat: add firebase-powered live chess matches page

### DIFF
--- a/app/index.html
+++ b/app/index.html
@@ -17,6 +17,9 @@
 		<script defer type="text/javascript" src="../assets/libraries/klaro/klaro.js"></script>
 		<script type="module" src="../assets/js/bit-load-modules.js"></script>
 		<script src="../assets/js/bit-globals.js"></script>
+		<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+		<script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-database-compat.js"></script>
+		<script src="../assets/js/bit-live-chess-firebase.js"></script>
 		<script src="../assets/libraries/CommLink/CommLink.js"></script>
 		<script src="../assets/js/bit-userscript-bridge.js"></script>
 		<script src="../assets/js/bit-i18n-processor.js"></script>

--- a/assets/js/bit-backend-manager.js
+++ b/assets/js/bit-backend-manager.js
@@ -16,6 +16,15 @@ function createInstance(domain, instanceID, chessVariant) {
             'date': Date.now(),
         });
 
+        window.bitLiveChessFirebase?.publishMatch({
+            id: instanceID,
+            domain,
+            variant: chessVariant,
+            detectedAt: Date.now()
+        }).catch(err => {
+            console.error('[Bit/Firebase] Failed to publish match:', err);
+        });
+
         log.success(`New engine instance created! (DOMAIN: ${domain}, ID: ${instanceID})`);
     } else {
         prelongInstanceLife(domain, instanceID, chessVariant);
@@ -33,6 +42,14 @@ function prelongInstanceLife(domain, instanceID, chessVariant) {
 
     if(instanceObj) {
         instanceObj.date = Date.now();
+
+        window.bitLiveChessFirebase?.publishMatch({
+            id: instanceID,
+            domain,
+            variant: chessVariant
+        }).catch(err => {
+            console.error('[Bit/Firebase] Failed to update match heartbeat:', err);
+        });
 
         const i = instanceObj.instance;
         const instanceProfiles = Object.keys(i.pV);
@@ -61,6 +78,10 @@ function prelongInstanceLife(domain, instanceID, chessVariant) {
 
 function removeInstance(instance) {
     instances = instances.filter(x => x.id != instance.instanceID);
+
+    window.bitLiveChessFirebase?.removeMatch(instance.instanceID).catch(err => {
+        console.error('[Bit/Firebase] Failed to remove live match:', err);
+    });
 
     removeInstanceFromSettingsDropdown(instance.instanceID);
 }

--- a/assets/js/bit-live-chess-firebase.js
+++ b/assets/js/bit-live-chess-firebase.js
@@ -1,0 +1,92 @@
+(function() {
+    const DEFAULT_CONFIG = {
+        apiKey: 'REPLACE_WITH_FIREBASE_API_KEY',
+        authDomain: 'REPLACE_WITH_FIREBASE_AUTH_DOMAIN',
+        databaseURL: 'REPLACE_WITH_FIREBASE_DATABASE_URL',
+        projectId: 'REPLACE_WITH_FIREBASE_PROJECT_ID',
+        storageBucket: 'REPLACE_WITH_FIREBASE_STORAGE_BUCKET',
+        messagingSenderId: 'REPLACE_WITH_FIREBASE_MESSAGING_SENDER_ID',
+        appId: 'REPLACE_WITH_FIREBASE_APP_ID'
+    };
+
+    const config = window.BIT_FIREBASE_CONFIG || DEFAULT_CONFIG;
+    const hasValidConfig = config.databaseURL && !config.databaseURL.includes('REPLACE_WITH_FIREBASE');
+
+    function isFirebaseReady() {
+        return typeof window.firebase !== 'undefined' && hasValidConfig;
+    }
+
+    function initFirebase() {
+        if(!isFirebaseReady()) return null;
+
+        try {
+            if(!window.firebase.apps.length) {
+                window.firebase.initializeApp(config);
+            }
+
+            return window.firebase.database();
+        } catch(error) {
+            console.error('[Bit/Firebase] Initialization failed:', error);
+            return null;
+        }
+    }
+
+    function getMatchRef(matchId) {
+        const db = initFirebase();
+
+        if(!db || !matchId) return null;
+
+        return db.ref(`liveChessMatches/${matchId}`);
+    }
+
+    async function publishMatch(matchData) {
+        const { id } = matchData || {};
+        const ref = getMatchRef(id);
+
+        if(!ref) return false;
+
+        const payload = {
+            ...matchData,
+            status: 'active',
+            lastSeenAt: Date.now()
+        };
+
+        await ref.update(payload);
+
+        return true;
+    }
+
+    async function removeMatch(matchId) {
+        const ref = getMatchRef(matchId);
+
+        if(!ref) return false;
+
+        await ref.remove();
+
+        return true;
+    }
+
+    function subscribeLiveMatches(onChange) {
+        const db = initFirebase();
+
+        if(!db || typeof onChange !== 'function') {
+            return () => {};
+        }
+
+        const ref = db.ref('liveChessMatches');
+        const listener = snapshot => {
+            onChange(snapshot.val() || {});
+        };
+
+        ref.on('value', listener);
+
+        return () => ref.off('value', listener);
+    }
+
+    window.bitLiveChessFirebase = {
+        isConfigured: hasValidConfig,
+        publishMatch,
+        removeMatch,
+        subscribeLiveMatches
+    };
+})();

--- a/live-chess-matches/index.html
+++ b/live-chess-matches/index.html
@@ -1,0 +1,25 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+    <meta charset="UTF-8">
+    <meta name="viewport" content="width=device-width, initial-scale=1.0">
+    <title>Live Chess Matches / Bit</title>
+    <link rel="stylesheet" href="live-chess-matches.css">
+    <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-app-compat.js"></script>
+    <script src="https://www.gstatic.com/firebasejs/10.12.2/firebase-database-compat.js"></script>
+    <script src="../assets/js/bit-live-chess-firebase.js"></script>
+</head>
+<body>
+    <main class="container">
+        <h1>Live Chess Matches</h1>
+        <p class="subtitle">Matches detected by Bit in real time.</p>
+        <div id="config-warning" class="warning hidden">
+            Firebase is not configured. Set <code>window.BIT_FIREBASE_CONFIG</code> before loading this page.
+        </div>
+        <section id="matches" class="matches"></section>
+        <p id="empty-state" class="empty-state">No active matches detected yet.</p>
+    </main>
+
+    <script src="live-chess-matches.js"></script>
+</body>
+</html>

--- a/live-chess-matches/live-chess-matches.css
+++ b/live-chess-matches/live-chess-matches.css
@@ -1,0 +1,79 @@
+:root {
+    color-scheme: dark;
+    font-family: Inter, system-ui, -apple-system, sans-serif;
+}
+
+body {
+    margin: 0;
+    background: #0d1117;
+    color: #e6edf3;
+}
+
+.container {
+    max-width: 860px;
+    margin: 0 auto;
+    padding: 2rem 1rem 3rem;
+}
+
+h1 {
+    margin: 0;
+    font-size: 2rem;
+}
+
+.subtitle {
+    margin-top: .5rem;
+    color: #9ba7b4;
+}
+
+.warning {
+    background: #472203;
+    border: 1px solid #d29922;
+    color: #ffd58a;
+    border-radius: 8px;
+    padding: .85rem 1rem;
+    margin: 1rem 0;
+}
+
+.hidden {
+    display: none;
+}
+
+.matches {
+    display: grid;
+    gap: 0.75rem;
+    margin-top: 1rem;
+}
+
+.match-card {
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 10px;
+    padding: 1rem;
+}
+
+.match-header {
+    display: flex;
+    justify-content: space-between;
+    align-items: center;
+    gap: 1rem;
+}
+
+.badge {
+    background: #1f6feb;
+    padding: .2rem .6rem;
+    border-radius: 999px;
+    font-size: .75rem;
+    font-weight: 700;
+    text-transform: uppercase;
+}
+
+.small {
+    color: #9ba7b4;
+    font-size: .9rem;
+    margin-top: .4rem;
+}
+
+.empty-state {
+    color: #8b949e;
+    margin-top: 1rem;
+}

--- a/live-chess-matches/live-chess-matches.js
+++ b/live-chess-matches/live-chess-matches.js
@@ -1,0 +1,45 @@
+(function() {
+    const matchesElem = document.getElementById('matches');
+    const emptyStateElem = document.getElementById('empty-state');
+    const configWarningElem = document.getElementById('config-warning');
+
+    function relativeTime(timestamp) {
+        if(!timestamp) return 'Unknown';
+
+        const seconds = Math.floor((Date.now() - timestamp) / 1000);
+
+        if(seconds < 60) return `${seconds}s ago`;
+        if(seconds < 3600) return `${Math.floor(seconds / 60)}m ago`;
+
+        return `${Math.floor(seconds / 3600)}h ago`;
+    }
+
+    function renderMatches(data) {
+        const entries = Object.values(data || {}).sort((a, b) => (b.lastSeenAt || 0) - (a.lastSeenAt || 0));
+
+        matchesElem.innerHTML = '';
+        emptyStateElem.style.display = entries.length ? 'none' : 'block';
+
+        entries.forEach(match => {
+            const card = document.createElement('article');
+            card.className = 'match-card';
+            card.innerHTML = `
+                <div class="match-header">
+                    <strong>${match.domain || 'Unknown domain'}</strong>
+                    <span class="badge">${match.variant || 'chess'}</span>
+                </div>
+                <div class="small">Match ID: ${match.id || 'n/a'}</div>
+                <div class="small">Detected: ${relativeTime(match.detectedAt)}</div>
+                <div class="small">Last seen: ${relativeTime(match.lastSeenAt)}</div>
+            `;
+
+            matchesElem.appendChild(card);
+        });
+    }
+
+    if(!window.bitLiveChessFirebase?.isConfigured) {
+        configWarningElem.classList.remove('hidden');
+    }
+
+    window.bitLiveChessFirebase?.subscribeLiveMatches(renderMatches);
+})();


### PR DESCRIPTION
### Motivation
- Provide a realtime public view of currently-detected chess matches by publishing detected Bit instances to Firebase Realtime Database so matches can be observed outside the browser tab. 
- Reuse a small, configurable helper for Firebase so the rest of the codebase can publish/subscribe to live-match data without duplicating wiring. 
- Add a lightweight UI that subscribes to the database and renders active matches in real time for monitoring and diagnostics.

### Description
- Add `assets/js/bit-live-chess-firebase.js`, a helper that initializes from `window.BIT_FIREBASE_CONFIG` and exposes `publishMatch`, `removeMatch`, and `subscribeLiveMatches` that operate under `liveChessMatches/{matchId}`. 
- Wire lifecycle hooks in `assets/js/bit-backend-manager.js` to call `publishMatch` when instances are created or heartbeated and `removeMatch` when instances are removed. 
- Load Firebase compat SDK and the helper from `app/index.html` so the app can publish detections automatically. 
- Add a new page `live-chess-matches/` (HTML/CSS/JS) that subscribes to live matches and renders match cards with domain, variant, ID, and timestamps, and shows a config warning when Firebase is not configured.

### Testing
- Performed static checks with `node --check assets/js/bit-live-chess-firebase.js`, `node --check assets/js/bit-backend-manager.js`, and `node --check live-chess-matches/live-chess-matches.js`, all succeeded. 
- Served the repository locally with `python -m http.server 8000 --directory /workspace/Bit` and verified the new page loads; visual verification captured via Playwright screenshot. 
- Verified the UI displays the Firebase configuration warning when `window.BIT_FIREBASE_CONFIG` is not set and will subscribe to live data when valid credentials are provided.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69908c6624e883328699ae28b00470d9)