### PR TITLE
feat: add guided Firebase setup for live chess matches

### DIFF
--- a/live-chess-matches/README.md
+++ b/live-chess-matches/README.md
@@ -3,9 +3,11 @@
 1. Open Firebase console and create (or use) a project.
 2. Enable **Realtime Database**.
 3. Copy your **Web app config** JSON from Project settings (or at minimum your Realtime Database URL).
-4. Open `/live-chess-matches/` and paste the config JSON or URL into the setup box.
-5. Click **Save Config** and refresh the page.
-6. Open the Bit app (`/app/`) and start/detect games — they will appear on the live page.
+4. Open `/live-chess-matches/`.
+5. In the **Setup Firebase** box, paste your config JSON or URL.
+6. Click **Save Config**.
+7. Refresh both `/live-chess-matches/` and `/app/`.
+8. Keep the Bit app (`/app/`) open and start/detect games — they will appear on the live page.
 
 ## Data path
 
@@ -24,6 +26,6 @@ Each match contains:
 
 ## Quick URL-only setup example
 
-You can also paste only your URL, for example:
+You can paste only your URL, for example:
 
 - `https://bitbytelabs-56eb1-default-rtdb.firebaseio.com/`

--- a/live-chess-matches/index.html
+++ b/live-chess-matches/index.html
@@ -13,8 +13,18 @@
     <main class="container">
         <h1>Live Chess Matches</h1>
         <p class="subtitle">Matches detected by Bit in real time.</p>
+        <section id="setup-panel" class="setup-panel hidden">
+            <h2>Setup Firebase</h2>
+            <p>Paste your Firebase web config JSON or just your Realtime Database URL.</p>
+            <textarea id="config-input" rows="6" placeholder='{"databaseURL":"https://your-project-default-rtdb.firebaseio.com"}'></textarea>
+            <div class="setup-actions">
+                <button id="save-config" type="button">Save Config</button>
+                <button id="clear-config" type="button" class="secondary">Clear Saved Config</button>
+            </div>
+            <p id="setup-status" class="small"></p>
+        </section>
         <div id="config-warning" class="warning hidden">
-            Firebase is not configured. Set <code>window.BIT_FIREBASE_CONFIG</code> before loading this page.
+            Firebase is not configured yet. Use the setup panel below and reload this page.
         </div>
         <section id="matches" class="matches"></section>
         <p id="empty-state" class="empty-state">No active matches detected yet.</p>

--- a/live-chess-matches/live-chess-matches.css
+++ b/live-chess-matches/live-chess-matches.css
@@ -77,3 +77,59 @@ h1 {
     color: #8b949e;
     margin-top: 1rem;
 }
+
+
+.setup-panel {
+    margin-top: 1rem;
+    background: #161b22;
+    border: 1px solid #30363d;
+    border-radius: 10px;
+    padding: 1rem;
+}
+
+.setup-panel h2 {
+    margin: 0;
+    font-size: 1.2rem;
+}
+
+.setup-panel p {
+    margin: .6rem 0;
+    color: #9ba7b4;
+}
+
+#config-input {
+    width: 100%;
+    background: #0d1117;
+    border: 1px solid #30363d;
+    border-radius: 8px;
+    color: #e6edf3;
+    padding: .75rem;
+    box-sizing: border-box;
+    font-family: ui-monospace, SFMono-Regular, Menlo, Monaco, Consolas, monospace;
+}
+
+.setup-actions {
+    display: flex;
+    flex-wrap: wrap;
+    gap: .6rem;
+    margin-top: .7rem;
+}
+
+button {
+    border: 1px solid #1f6feb;
+    background: #1f6feb;
+    color: #fff;
+    border-radius: 7px;
+    font-weight: 600;
+    cursor: pointer;
+    padding: .55rem .9rem;
+}
+
+button.secondary {
+    background: transparent;
+    border-color: #30363d;
+}
+
+.status-error {
+    color: #ff8f8f;
+}

--- a/live-chess-matches/live-chess-matches.js
+++ b/live-chess-matches/live-chess-matches.js
@@ -2,6 +2,11 @@
     const matchesElem = document.getElementById('matches');
     const emptyStateElem = document.getElementById('empty-state');
     const configWarningElem = document.getElementById('config-warning');
+    const setupPanelElem = document.getElementById('setup-panel');
+    const configInputElem = document.getElementById('config-input');
+    const saveConfigButtonElem = document.getElementById('save-config');
+    const clearConfigButtonElem = document.getElementById('clear-config');
+    const setupStatusElem = document.getElementById('setup-status');
 
     function relativeTime(timestamp) {
         if(!timestamp) return 'Unknown';
@@ -37,9 +42,45 @@
         });
     }
 
+    function setStatus(message, isError = false) {
+        setupStatusElem.textContent = message;
+        setupStatusElem.classList.toggle('status-error', isError);
+    }
+
+    function setupFirebaseConfigUI() {
+        if(!setupPanelElem) {
+            return;
+        }
+
+        setupPanelElem.classList.remove('hidden');
+
+        if(window.bitLiveChessFirebase?.isConfigured) {
+            setStatus('Firebase config found. You can still replace it below.');
+        }
+
+        saveConfigButtonElem?.addEventListener('click', () => {
+            const rawValue = configInputElem?.value || '';
+            const isSaved = window.bitLiveChessFirebase?.saveConfig(rawValue);
+
+            if(isSaved) {
+                setStatus('Saved! Reload this page and keep /app/ open to start receiving live matches.');
+                configWarningElem?.classList.add('hidden');
+            } else {
+                setStatus('Could not save config. Please paste valid Firebase JSON or a database URL.', true);
+            }
+        });
+
+        clearConfigButtonElem?.addEventListener('click', () => {
+            window.bitLiveChessFirebase?.clearConfig();
+            setStatus('Saved config removed. Reload this page after adding a new one.');
+            configWarningElem?.classList.remove('hidden');
+        });
+    }
+
     if(!window.bitLiveChessFirebase?.isConfigured) {
         configWarningElem.classList.remove('hidden');
     }
 
+    setupFirebaseConfigUI();
     window.bitLiveChessFirebase?.subscribeLiveMatches(renderMatches);
 })();


### PR DESCRIPTION
### Motivation
- Make it easier to configure the live matches page without editing global JS by providing an in-page guided setup for Firebase configuration. 
- Allow non-technical users to provide either a full Firebase web config JSON or just a Realtime Database URL and persist it for the live page to use.

### Description
- Added a Firebase setup panel to `live-chess-matches/index.html` with a textarea and `Save`/`Clear` buttons for entering config. 
- Implemented UI behavior in `live-chess-matches/live-chess-matches.js` to show the setup panel, display status messages, and call save/clear helpers. 
- Extended the Firebase bridge `assets/js/bit-live-chess-firebase.js` to parse JSON or URL input, persist config to `localStorage` under `bit-live-chess-firebase-config`, reuse stored config on load, and expose `saveConfig`/`clearConfig` helpers and `isConfigured` flag. 
- Added styling for the setup panel in `live-chess-matches/live-chess-matches.css` and updated `live-chess-matches/README.md` to reflect the new setup flow.

### Testing
- Ran syntax checks with `node --check assets/js/bit-live-chess-firebase.js` and `node --check live-chess-matches/live-chess-matches.js`, both succeeded. 
- Served the site locally with `python3 -m http.server` and performed a manual UI validation including a Playwright screenshot of `/live-chess-matches/`, which succeeded. 
- Verified the live matches subscription flow remains unchanged (existing `subscribeLiveMatches` is still used) while the new setup UI shows status and persisted config behavior.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_699096c79e108332816606d374b5a33d)