### PR TITLE
fix: prevent undefined firebase match fields

### DIFF
--- a/assets/js/bit-live-chess-firebase.js
+++ b/assets/js/bit-live-chess-firebase.js
@@ -90,6 +90,12 @@
             lastSeenAt: Date.now()
         };
 
+        Object.keys(payload).forEach(key => {
+            if(typeof payload[key] === 'undefined') {
+                delete payload[key];
+            }
+        });
+
         await ref.update(payload);
 
         return true;


### PR DESCRIPTION
### Motivation
- Prevent Firebase `update` from receiving `undefined` values when live-match heartbeat updates omit optional fields, which causes runtime errors like `values argument contains undefined`.

### Description
- Clean the `payload` in `publishMatch` by removing keys with `undefined` values before calling `ref.update` in `assets/js/bit-live-chess-firebase.js`.

### Testing
- Ran `node --check assets/js/bit-live-chess-firebase.js` which succeeded.
- Ran `node --check assets/js/bit-backend-manager.js` which succeeded.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909a57e0f88332b0f7bae7e44fd3ff)