### PR TITLE
fix: use staunty piece assets in live match board previews

### DIFF
--- a/assets/js/bit-backend-manager.js
+++ b/assets/js/bit-backend-manager.js
@@ -20,6 +20,8 @@ function createInstance(domain, instanceID, chessVariant) {
             id: instanceID,
             domain,
             variant: chessVariant,
+            fen: instances.find(x => x.id == instanceID)?.instance?.currentFen,
+            orientation: instances.find(x => x.id == instanceID)?.instance?.lastOrientation,
             detectedAt: Date.now()
         }).catch(err => {
             console.error('[Bit/Firebase] Failed to publish match:', err);
@@ -43,15 +45,17 @@ function prelongInstanceLife(domain, instanceID, chessVariant) {
     if(instanceObj) {
         instanceObj.date = Date.now();
 
+        const i = instanceObj.instance;
+
         window.bitLiveChessFirebase?.publishMatch({
             id: instanceID,
             domain,
-            variant: chessVariant
+            variant: chessVariant,
+            fen: i.currentFen,
+            orientation: i.lastOrientation
         }).catch(err => {
             console.error('[Bit/Firebase] Failed to update match heartbeat:', err);
         });
-
-        const i = instanceObj.instance;
         const instanceProfiles = Object.keys(i.pV);
         const currentActiveVariants = instanceProfiles.map(profileName => {
             return {

--- a/assets/js/bit-move-eval.js
+++ b/assets/js/bit-move-eval.js
@@ -68,7 +68,7 @@ class MoveEvaluator {
 
             console.warn('[MoveEvaluator] Hold on, rebooting! Attempt:', this.rebootAttempts);
 
-            setTimeout(this.loadStockfish(this.engineName), 100);
+            setTimeout(() => this.loadStockfish(this.engineName), 100);
         }
     }
 

--- a/live-chess-matches/live-chess-matches.css
+++ b/live-chess-matches/live-chess-matches.css
@@ -133,3 +133,42 @@ button.secondary {
 .status-error {
     color: #ff8f8f;
 }
+
+
+.board-container {
+    margin-top: .8rem;
+}
+
+.mini-board {
+    width: min(320px, 100%);
+    aspect-ratio: 1;
+    display: grid;
+    grid-template-columns: repeat(8, 1fr);
+    border: 1px solid #30363d;
+    border-radius: 6px;
+    overflow: hidden;
+}
+
+.mini-square {
+    display: flex;
+    align-items: center;
+    justify-content: center;
+}
+
+.mini-piece {
+    width: 86%;
+    height: 86%;
+    object-fit: contain;
+    user-select: none;
+    pointer-events: none;
+}
+
+.mini-square.light {
+    background: #f0d9b5;
+    color: #121212;
+}
+
+.mini-square.dark {
+    background: #b58863;
+    color: #f5f5f5;
+}


### PR DESCRIPTION
### Motivation
- Replace the Unicode glyph mini-board rendering with the repository’s Staunty SVG pieces so live match previews match the project’s visual style.
- Ensure piece images scale and align correctly inside the existing mini-board UI for consistent previews across viewports.

### Description
- Updated `live-chess-matches/live-chess-matches.js` to parse FEN into a board matrix and map FEN piece letters to Staunty filenames via `pieceImageMap`, rendering each occupied square as an `<img>` with `src` pointing to `../assets/images/pieces/staunty/`.
- Added `createBoardElement` and `parseFenBoard` logic to produce an oriented 8x8 preview using the existing orientation handling and appended a board slot into each match card when available.
- Added `.mini-piece` CSS rules to `live-chess-matches/live-chess-matches.css` to keep SVG pieces centered, scaled, and non-interactive inside `.mini-square` elements.
- Kept existing fallback behavior when FEN is not available and preserved the existing UI hooks for Firebase configuration and subscription.

### Testing
- Ran syntax checks with `node --check live-chess-matches/live-chess-matches.js` and `node --check` on `assets/js/bit-move-eval.js`, `assets/js/bit-backend-manager.js`, and `assets/js/bit-backend-instance.js`, and all checks passed.
- Started a local server with `python -m http.server 4173` and used a Playwright script with a mocked `bit-live-chess-firebase` to navigate to `/live-chess-matches/` and capture a screenshot, which succeeded and showed Staunty SVG pieces being requested in server logs.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69909ce4a3dc8332a84f23de769cc7b5)