### PR TITLE
fix: even board sizing and hardcode firebase url

### DIFF
--- a/assets/js/bit-backend-instance.js
+++ b/assets/js/bit-backend-instance.js
@@ -2352,12 +2352,21 @@ class BackendInstance {
             const chessgroundElem = this.instanceElem.querySelector('.chessground-x');
 
             chessboardComponentsElem.classList.add(chessFont);
+
+            const updateBoardSize = containerWidth => {
+                const fileSizePx = Math.max(1, Math.floor(containerWidth / boardDimensions.width));
+                const boardWidthPx = fileSizePx * boardDimensions.width;
+                const boardHeightPx = fileSizePx * boardDimensions.height;
+
+                chessgroundElem.style.width = `${boardWidthPx}px`;
+                chessgroundElem.style.height = `${boardHeightPx}px`;
+            };
             
             new ResizeObserver(entries => {
                 const width = entries[0].target.getBoundingClientRect().width;
 
-                chessgroundElem.style.height = `${getBoardHeightFromWidth(width, boardDimensions)}px`;
-            }).observe(chessgroundElem);
+                updateBoardSize(width);
+            }).observe(chessboardComponentsElem);
 
             this.chessground = window.ChessgroundX(chessgroundElem, { 
                 disableContextMenu: true,

--- a/assets/js/bit-live-chess-firebase.js
+++ b/assets/js/bit-live-chess-firebase.js
@@ -1,54 +1,12 @@
 (function() {
-    const STORAGE_KEY = 'bit-live-chess-firebase-config';
+    const DATABASE_URL = 'https://bitbytelabs-56eb1-default-rtdb.firebaseio.com/';
 
-    const DEFAULT_CONFIG = {
-        apiKey: 'REPLACE_WITH_FIREBASE_API_KEY',
-        authDomain: 'REPLACE_WITH_FIREBASE_AUTH_DOMAIN',
-        databaseURL: 'REPLACE_WITH_FIREBASE_DATABASE_URL',
-        projectId: 'REPLACE_WITH_FIREBASE_PROJECT_ID',
-        storageBucket: 'REPLACE_WITH_FIREBASE_STORAGE_BUCKET',
-        messagingSenderId: 'REPLACE_WITH_FIREBASE_MESSAGING_SENDER_ID',
-        appId: 'REPLACE_WITH_FIREBASE_APP_ID'
+    const config = {
+        databaseURL: DATABASE_URL
     };
 
-    function parseConfigInput(rawValue) {
-        if(!rawValue || typeof rawValue !== 'string') {
-            return null;
-        }
-
-        const trimmedValue = rawValue.trim();
-
-        if(!trimmedValue) {
-            return null;
-        }
-
-        if(trimmedValue.startsWith('{')) {
-            try {
-                return JSON.parse(trimmedValue);
-            } catch(error) {
-                console.error('[Bit/Firebase] Failed to parse config JSON:', error);
-                return null;
-            }
-        }
-
-        if(trimmedValue.startsWith('http://') || trimmedValue.startsWith('https://')) {
-            return {
-                ...DEFAULT_CONFIG,
-                databaseURL: trimmedValue
-            };
-        }
-
-        return null;
-    }
-
-    function getStoredConfig() {
-        return parseConfigInput(window.localStorage.getItem(STORAGE_KEY));
-    }
-
-    let config = window.BIT_FIREBASE_CONFIG || getStoredConfig() || DEFAULT_CONFIG;
-
     function hasValidConfig(configObj) {
-        return configObj?.databaseURL && !configObj.databaseURL.includes('REPLACE_WITH_FIREBASE');
+        return configObj?.databaseURL;
     }
 
     function isFirebaseReady() {
@@ -130,24 +88,7 @@
 
     window.bitLiveChessFirebase = {
         isConfigured: hasValidConfig(config),
-        configStorageKey: STORAGE_KEY,
-        parseConfigInput,
-        saveConfig(rawValue) {
-            const parsedConfig = parseConfigInput(rawValue);
-
-            if(!parsedConfig || !hasValidConfig(parsedConfig)) {
-                return false;
-            }
-
-            window.localStorage.setItem(STORAGE_KEY, JSON.stringify(parsedConfig));
-            config = parsedConfig;
-
-            return true;
-        },
-        clearConfig() {
-            window.localStorage.removeItem(STORAGE_KEY);
-            config = DEFAULT_CONFIG;
-        },
+        databaseURL: DATABASE_URL,
         publishMatch,
         removeMatch,
         subscribeLiveMatches


### PR DESCRIPTION
### Motivation
- The on-board rendering produced visually uneven squares on some container sizes because the board height was computed from a float width resulting in fractional square sizes. 
- The Firebase helper contained an interactive/localStorage-driven config flow and placeholder values which should be removed in favor of the provided realtime database URL.

### Description
- Snap board rendering to whole-square pixels by adding an `updateBoardSize` helper that computes `fileSizePx = Math.floor(containerWidth / boardDimensions.width)` and sets both `chessgroundElem.style.width` and `chessgroundElem.style.height` accordingly. 
- Use a `ResizeObserver` on the board container (`chessboardComponentsElem`) and call `updateBoardSize` on resize so file/rank sizes remain even. 
- Simplify `assets/js/bit-live-chess-firebase.js` by adding a `DATABASE_URL` constant with the provided URL, creating a minimal `config` with only `databaseURL`, removing parsing/storage/clear helpers, and exposing `databaseURL` plus `publishMatch`, `removeMatch`, and `subscribeLiveMatches`.

### Testing
- Ran `node --check assets/js/bit-live-chess-firebase.js` and `node --check assets/js/bit-backend-instance.js`, both completed successfully. 
- Served the app with `python3 -m http.server 4173` and loaded `http://127.0.0.1:4173/app/index.html` for a UI smoke check which completed and served required assets. 
- Attempted an automated screenshot with Playwright where Chromium failed to launch in the environment, and the Firefox-based run succeeded and produced a full-page screenshot of the page.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a4d0dd24833294393a832cb05772)