### PR TITLE
feat: add firebase initialization script to all html pages

### DIFF
--- a/404.html
+++ b/404.html
@@ -34,5 +34,29 @@
 
         <p class="helper-text">Tip: verify the URL or start from the homepage.</p>
     </main>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/app/index.html
+++ b/app/index.html
@@ -753,5 +753,29 @@
 		<script src="../assets/js/bit-backend-gui-pip.js"></script>
 		<script src="../assets/js/bit-backend-gui.js?new=true"></script>
 		<script src="index.js"></script>
-	</body>
+	<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
+</body>
 </html>

--- a/assets/libraries/chessgroundx/demo.html
+++ b/assets/libraries/chessgroundx/demo.html
@@ -28,5 +28,29 @@
   </head>
   <body>
     <div id="chessground"></div>
-  </body>
+  <script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
+</body>
 </html>

--- a/blog/index.html
+++ b/blog/index.html
@@ -90,5 +90,29 @@
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/board/index.html
+++ b/board/index.html
@@ -88,4 +88,28 @@
 			}
 		})();
     </script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>

--- a/contributing/index.html
+++ b/contributing/index.html
@@ -96,5 +96,29 @@
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/development/index.html
+++ b/development/index.html
@@ -85,5 +85,29 @@
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/faq/index.html
+++ b/faq/index.html
@@ -143,5 +143,29 @@
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/index.html
+++ b/index.html
@@ -154,5 +154,29 @@
         </footer>
     </main>
     <script async="" src="assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/install/index.html
+++ b/install/index.html
@@ -100,5 +100,29 @@
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/live-chess-matches/index.html
+++ b/live-chess-matches/index.html
@@ -31,5 +31,29 @@
     </main>
 
     <script src="live-chess-matches.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/privacy/index.html
+++ b/privacy/index.html
@@ -64,5 +64,29 @@
                 This website contains links to external sites. Bit is not responsible for the privacy practices or content of external websites. This Privacy Policy may be updated at any time. Continued use of Bit after such changes constitutes acceptance of the updated policy.
             </div>
         </div>
-    </body>
+    <script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
+</body>
 </html>

--- a/tos/index.html
+++ b/tos/index.html
@@ -27,5 +27,29 @@
         
             <div class="small-paragraph extra-slim center-text">By using Bit, you confirm that you have read and agree to these Terms of Service.</div>
         </div>     
-    </body>
+    <script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
+</body>
 </html>

--- a/troubleshoot/index.html
+++ b/troubleshoot/index.html
@@ -89,5 +89,29 @@
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>

--- a/usage/index.html
+++ b/usage/index.html
@@ -174,5 +174,29 @@
         </footer>
     </main>
     <script async="" src="../assets/js/site-additional-content.js"></script>
+<script type="module">
+  // Import the functions you need from the SDKs you need
+  import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
+  import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  // TODO: Add SDKs for Firebase products that you want to use
+  // https://firebase.google.com/docs/web/setup#available-libraries
+
+  // Your web app's Firebase configuration
+  // For Firebase JS SDK v7.20.0 and later, measurementId is optional
+  const firebaseConfig = {
+    apiKey: "AIzaSyAyku_mtqjtN2fhsHweQ8C5rh5nZT4X9ec",
+    authDomain: "bitbytelabs-56eb1.firebaseapp.com",
+    databaseURL: "https://bitbytelabs-56eb1-default-rtdb.firebaseio.com",
+    projectId: "bitbytelabs-56eb1",
+    storageBucket: "bitbytelabs-56eb1.firebasestorage.app",
+    messagingSenderId: "925575010294",
+    appId: "1:925575010294:web:ac7e7aafabf8b05bce99d7",
+    measurementId: "G-EQ53N2L5E9"
+  };
+
+  // Initialize Firebase
+  const app = initializeApp(firebaseConfig);
+  const analytics = getAnalytics(app);
+</script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Ensure Firebase is initialized before any Firebase services are used by adding the provided module-based initialization snippet to every HTML page that contains a `<body>` element. 
- Make the same Firebase configuration present site-wide so pages that later use Firebase have a consistent setup. 
- Avoid changing surrounding page logic by appending the snippet at the end of each page body. 

### Description
- Added the provided Firebase v12.9.0 `<script type="module">` initialization block immediately before the closing `</body>` tag across 15 HTML files. 
- Files modified: `404.html`, `app/index.html`, `assets/libraries/chessgroundx/demo.html`, `blog/index.html`, `board/index.html`, `contributing/index.html`, `development/index.html`, `faq/index.html`, `index.html`, `install/index.html`, `live-chess-matches/index.html`, `privacy/index.html`, `tos/index.html`, `troubleshoot/index.html`, and `usage/index.html`. 
- Change size: `15 files changed, 364 insertions(+), 4 deletions(-)`, committed with the conventional commit `feat: add firebase initialization script to all html pages`. 

### Testing
- Ran a Python validation script that checked every `*.html` containing a `</body>` now includes the Firebase `measurementId: "G-EQ53N2L5E9"`, result: `PASS`. 
- Verified presence of the `measurementId` with `rg -n "measurementId: \"G-EQ53N2L5E9\""` across the updated files, which returned matches in all modified pages.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990a6cea57c8332b38d09513b6fd7b2)