### PR TITLE
feat: add firebase login and signup

### DIFF
--- a/index.html
+++ b/index.html
@@ -145,6 +145,22 @@
                 <section>
                     <p class="install-suggestion">Ready to begin? <a href="install/" class="install-button fancy-btn">Let's get it!</a></p>
                 </section>
+                <section>
+                    <div id="firebase-auth" style="max-width: 520px; margin: 0 auto; padding: 20px; border: 1px solid rgba(255,255,255,.15); border-radius: 12px; background: rgba(0,0,0,.2);">
+                        <h2 style="margin-top: 0;">Firebase Login / Signup</h2>
+                        <p style="margin-bottom: 14px;">Create an account or sign in with your email and password.</p>
+                        <div style="display: grid; gap: 10px;">
+                            <input id="auth-email" type="email" placeholder="Email" autocomplete="email" style="padding: 10px 12px; border-radius: 8px; border: 1px solid #494949; background: #1c1c1c; color: #fff;" />
+                            <input id="auth-password" type="password" placeholder="Password" autocomplete="current-password" style="padding: 10px 12px; border-radius: 8px; border: 1px solid #494949; background: #1c1c1c; color: #fff;" />
+                            <div style="display: flex; gap: 10px; flex-wrap: wrap;">
+                                <button id="auth-login" class="fancy-btn" type="button">Login</button>
+                                <button id="auth-signup" class="fancy-btn" type="button">Sign up</button>
+                                <button id="auth-logout" class="fancy-btn" type="button">Logout</button>
+                            </div>
+                        </div>
+                        <p id="auth-status" style="margin-bottom: 0; margin-top: 12px;">Not signed in.</p>
+                    </div>
+                </section>
             </article>
             <!-- PAGE CONTENT ENDS -->
         </section>
@@ -158,6 +174,7 @@
   // Import the functions you need from the SDKs you need
   import { initializeApp } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-app.js";
   import { getAnalytics } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-analytics.js";
+  import { getAuth, createUserWithEmailAndPassword, signInWithEmailAndPassword, signOut, onAuthStateChanged } from "https://www.gstatic.com/firebasejs/12.9.0/firebase-auth.js";
   // TODO: Add SDKs for Firebase products that you want to use
   // https://firebase.google.com/docs/web/setup#available-libraries
 
@@ -177,6 +194,73 @@
   // Initialize Firebase
   const app = initializeApp(firebaseConfig);
   const analytics = getAnalytics(app);
+  const auth = getAuth(app);
+
+  const emailInput = document.getElementById('auth-email');
+  const passwordInput = document.getElementById('auth-password');
+  const loginButton = document.getElementById('auth-login');
+  const signupButton = document.getElementById('auth-signup');
+  const logoutButton = document.getElementById('auth-logout');
+  const statusText = document.getElementById('auth-status');
+
+  function setStatus(message) {
+    statusText.textContent = message;
+  }
+
+  function getCredentials() {
+    return {
+      email: emailInput.value.trim(),
+      password: passwordInput.value
+    };
+  }
+
+  signupButton.addEventListener('click', async () => {
+    const { email, password } = getCredentials();
+
+    if(!email || !password) {
+      setStatus('Please enter both email and password.');
+      return;
+    }
+
+    try {
+      const credential = await createUserWithEmailAndPassword(auth, email, password);
+      setStatus(`Signed up as ${credential.user.email}.`);
+    } catch(error) {
+      setStatus(`Signup failed: ${error.message}`);
+    }
+  });
+
+  loginButton.addEventListener('click', async () => {
+    const { email, password } = getCredentials();
+
+    if(!email || !password) {
+      setStatus('Please enter both email and password.');
+      return;
+    }
+
+    try {
+      const credential = await signInWithEmailAndPassword(auth, email, password);
+      setStatus(`Logged in as ${credential.user.email}.`);
+    } catch(error) {
+      setStatus(`Login failed: ${error.message}`);
+    }
+  });
+
+  logoutButton.addEventListener('click', async () => {
+    try {
+      await signOut(auth);
+      setStatus('Logged out.');
+    } catch(error) {
+      setStatus(`Logout failed: ${error.message}`);
+    }
+  });
+
+  onAuthStateChanged(auth, (user) => {
+    if(user)
+      setStatus(`Signed in as ${user.email}.`);
+    else
+      setStatus('Not signed in.');
+  });
 </script>
 </body>
 </html>


### PR DESCRIPTION
### Motivation
- Provide a simple on-page Firebase authentication UI so users can sign up and log in with email/password on the home page.
- Reuse the existing Firebase initialization block to enable auth flows without duplicating SDK initialization or script blocks.

### Description
- Add a new `#firebase-auth` panel in `index.html` with email and password inputs, `Login`, `Sign up`, `Logout` buttons and a live `#auth-status` message.
- Import `firebase-auth` and call `getAuth(app)`, then wire `createUserWithEmailAndPassword`, `signInWithEmailAndPassword`, `signOut`, and `onAuthStateChanged` to the UI elements.
- Implement client-side handlers that validate inputs, perform signup/login/logout, and update the status text with success or error messages, while keeping a single `initializeApp(firebaseConfig)` instance on the page.

### Testing
- Verified presence of the new UI and imports with `rg -n "initializeApp\(|firebase-auth\.js|id=\"firebase-auth\"" index.html` which returned expected matches (success).
- Served the site with `python3 -m http.server 4173` and performed a local page load to ensure the page and scripts are reachable (server started and returned 200 for HTML and assets as available).
- Ran a Playwright smoke script (via the test harness) that loaded `http://127.0.0.1:4173/index.html`, asserted `#auth-login`, `#auth-signup`, and `#auth-logout` exist, and captured a screenshot; the script completed successfully and assertions passed.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990ae3df15083328fea8f4f1bac2530)