### PR TITLE
fix: remove duplicated Firebase init scripts and standardize GUI title

### DIFF
--- a/assets/js/bit-backend-gui.js
+++ b/assets/js/bit-backend-gui.js
@@ -131,7 +131,7 @@ let lastProfileID = null;
         const userscriptManagerData = [GM_info?.scriptHandler, GM_info?.version]?.join(' ');
         const userscriptData = [GM_info?.script?.author, GM_info?.script?.version]?.join(' ');
     
-        document.title = `A.C.A.S (Using ${userscriptData})`;
+        document.title = `Bit (Using ${userscriptData})`;
     
         if(GM_info?.script?.version && isBelowVersion(GM_info?.script?.version, '2.3.0')) {
             updateYourUserscriptElem.classList.remove('hidden');


### PR DESCRIPTION
### Motivation
- Multiple HTML pages contained duplicate Firebase module initialization blocks which caused redundant imports and potential initialization conflicts.
- A minor UI text inconsistency existed in `assets/js/bit-backend-gui.js` where the page title used `A.C.A.S` instead of the project name.

### Description
- Removed the duplicate `<script type="module" id="bit-firebase-init">` blocks from 16 HTML files so each page retains a single Firebase module initialization snippet (`initializeApp`/`getAnalytics`).
- Ensured no HTML file contains more than one `const firebaseConfig = {` declaration and removed all `bit-firebase-init` occurrences appended by the previous change.
- Updated `assets/js/bit-backend-gui.js` to change `document.title = `A.C.A.S (Using ${userscriptData})`;` to `document.title = `Bit (Using ${userscriptData})`;` and normalized the file ending newline.
- Committed with a Conventional Commit message `fix: remove duplicated firebase init scripts` to comply with the repository's release/action expectations.

### Testing
- Ran a repository-wide search with `rg` to locate duplicate Firebase imports and confirmed affected files (success).
- Executed Python scripts to remove the appended duplicate module blocks and then verified with a script that no file contains more than one `firebaseConfig` and that `bit-firebase-init` occurrences are zero (success).
- Inspected each modified HTML to confirm exactly one `initializeApp` import snippet remains near the bottom of `<body>` (success).
- Ran `git diff --check` and committed the changes; the commit completed without formatting errors (success).

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6990b82cc8f48332a21fc33e9900a7db)