### PR TITLE
Potential fix for code scanning alert no. 7: Incomplete string escaping or encoding

### DIFF
--- a/assets/libraries/chessgroundx/src/util.ts
+++ b/assets/libraries/chessgroundx/src/util.ts
@@ -22,7 +22,7 @@ export const pos2key = (pos: cg.Pos): cg.Key => (cg.files[pos[0]] + cg.ranks[pos
 export const key2pos = (k: cg.Key): cg.Pos => [k.charCodeAt(0) - 97, k.charCodeAt(1) - 49];
 
 export function roleOf(letter: cg.Letter | cg.DropOrig): cg.Role {
-  return (letter.replace('+', 'p').replace('*', '_').replace('@', '').toLowerCase() + '-piece') as cg.Role;
+  return (letter.replace(/\+/g, 'p').replace(/\*/g, '_').replace(/@/g, '').toLowerCase() + '-piece') as cg.Role;
 }
 
 export function letterOf(role: cg.Role, uppercase = false): cg.Letter {


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/7](https://github.com/bitbytelabs/Bit/security/code-scanning/7)

In general, to fix incomplete string escaping/encoding when using `replace`, change from string patterns (which only affect the first occurrence) to regular expressions with the global (`g`) flag so that *all* occurrences are processed. Alternatively, use a well-tested library function for the specific escaping/normalization task.

For this codebase, the best minimal change is to update `roleOf` so that each `replace` uses a global regex: `replace(/\+/g, 'p')`, `replace(/\*/g, '_')`, and `replace(/@/g, '')`. This preserves all existing behavior for strings with a single occurrence of these characters, while correctly handling multiple occurrences and avoiding partial normalization. No other functions need to change, since `letterOf` already uses `replace('p', '+')` and `replace('_', '*')` in a context (`letterPart.length > 1 ? ...`) where the semantics likely assume a single promotion/file designator; there’s no explicit warning for those lines, and altering them could unintentionally change encoding rules.

Concretely:

- Edit `assets/libraries/chessgroundx/src/util.ts`.
- On line 25, change the chain of `replace` calls to use global regular expressions.
- No new imports or helper methods are required; we rely on built-in `String.prototype.replace` with regex patterns.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
