### PR TITLE
feat: add Stockfish 8 to engine usage list

### DIFF
--- a/usage/index.html
+++ b/usage/index.html
@@ -106,6 +106,7 @@
                     <p>The <a target="_about" href="../app?shl=chessEngine">Chess Engine</a> setting changes the engine which is used to calculate moves. We recommend using <strong>Stockfish 17 WASM</strong> as its the fastest and strongest engine, although it does not play like a human and has a hard time playing badly. If you want to play chess variants, use <strong>Fairy Stockfish 14</strong>. You can access Lc0 and Fairy Stockfish engines via the <code>?sab=true</code> URL parameter. It enables SharedArrayBuffer required by those engines.</p>
                     <ul>
                         <li>Stockfish &lt;17 (The strongest gameplay)</li>
+                        <li>Stockfish 8 (Legacy lightweight JS engine)</li>
                         <li>Fairy Stockfish 14 (Chess variants)</li>
                         <li>Maia 2 (Realistic human-like gameplay)</li>
                         <li>Lc0 with Maia (Semi-realistic human-like gameplay)</li>


### PR DESCRIPTION
### Motivation
- Document that the legacy Stockfish 8 JS engine is available so users can discover and choose the lightweight legacy engine.

### Description
- Added `Stockfish 8 (Legacy lightweight JS engine)` to the Chess Engine list in `usage/index.html` and did not modify other engine assets or init blocks.

### Testing
- Ran `git diff --check` and committed the change (`feat: add Stockfish 8 to engine usage list`), verified the addition with `rg -n "Stockfish 8 \(Legacy lightweight JS engine\)" usage/index.html`, checked Firebase import/init counts with a Python script which reported a pre-existing duplicate import in `auth/index.html` but confirmed this change introduced no new duplicates, and started a local server with `python -m http.server 4173` and captured a Playwright screenshot of `/usage/` which loaded successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69913130e21c833287fb53e0dbf9b707)