### PR TITLE
Potential fix for code scanning alert no. 71: Incomplete URL substring sanitization

### DIFF
--- a/index.js
+++ b/index.js
@@ -11,7 +11,11 @@ const githubUpdateCheckConfig = {
     'checkInterval': 3 * 60 * 1000
 };
 
-const isGithubPagesHost = window.location.hostname.endsWith('github.io');
+const allowedGithubPagesHosts = [
+    'bitbytelabs.github.io'
+];
+
+const isGithubPagesHost = allowedGithubPagesHosts.includes(window.location.hostname);
 const isDevelopmentHost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
 
 async function getLatestCommitSha() {


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/71](https://github.com/bitbytelabs/Bit/security/code-scanning/71)

In general, to avoid incomplete hostname checks, you should never use substring or suffix checks to determine whether a host is “trusted.” Instead, compare the parsed hostname against an explicit whitelist of allowed hosts, or otherwise enforce an exact match or tightly constrained pattern that cannot be spoofed by arbitrary prefixes.

For this code, the best fix with minimal functional change is to replace the loose `endsWith('github.io')` check with an explicit list of allowed hostnames for which this GitHub‑update auto‑reload behavior is intended. For example, if the site is served from `bitbytelabs.github.io` and possibly also from the custom domain `bitbytelabs.com`, we can define an `allowedHosts` array and compute `isGithubPagesHost` by checking `allowedHosts.includes(window.location.hostname)`. This preserves the original intention of only enabling the update watcher on specific deployment environments, while eliminating the overly broad suffix match that includes arbitrary `*.github.io` domains.

Concretely, in `index.js` around line 14, introduce an `allowedHosts` array (containing the exact hostnames you wish to support) and change the `isGithubPagesHost` assignment to use `includes` on that list instead of `.endsWith('github.io')`. No new imports or external libraries are needed; we only use standard JavaScript features. The rest of the code (the GitHub API call and interval reload logic) can remain unchanged.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
