### PR TITLE
Potential fix for code scanning alert no. 70: Incomplete URL substring sanitization

### DIFF
--- a/app/index.js
+++ b/app/index.js
@@ -5,7 +5,7 @@ const githubUpdateCheckConfig = {
     'checkInterval': 3 * 60 * 1000
 };
 
-const isGithubPagesHost = window.location.hostname.endsWith('github.io');
+const isGithubPagesHost = window.location.hostname === 'bitbytelabs.github.io';
 const isDevelopmentHost = window.location.hostname === 'localhost' || window.location.hostname === '127.0.0.1';
 
 async function getLatestCommitSha() {


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/70](https://github.com/bitbytelabs/Bit/security/code-scanning/70)

In general, to fix incomplete URL substring/suffix checks, you should compare the host against a precise, explicit whitelist (or a single exact value) instead of using substring methods such as `includes`, `indexOf`, or `endsWith`. When working with full URLs, parse them and then validate `hostname` against allowed values.

In this concrete case, the problematic code is:

```js
8: const isGithubPagesHost = window.location.hostname.endsWith('github.io');
```

If the intent is to limit the special “GitHub Pages” behavior to the project’s own GitHub Pages site, we should replace this with an exact comparison against the known hostname (for example, `bitbytelabs.github.io`). This avoids treating arbitrary `*.github.io` hosts as trusted and satisfies CodeQL’s concern. Assuming the repository in `githubUpdateCheckConfig.apiEndpoint` is `bitbytelabs/Bit`, the default GitHub Pages hostname would be `bitbytelabs.github.io`, so we can use that.

Concretely:

- In `app/index.js`, change the definition of `isGithubPagesHost` (line 8) to compare `window.location.hostname` to the specific GitHub Pages host string with `===`.
- No new helper methods are required.
- No new imports are needed because we’re only using standard globals (`window.location`).

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
