### PR TITLE
Potential fix for code scanning alert no. 13: Unvalidated dynamic method call

### DIFF
--- a/app/assets/engines/lila-stockfish/sf171-79.js
+++ b/app/assets/engines/lila-stockfish/sf171-79.js
@@ -416,6 +416,12 @@ var Sf17179Web = (() => {
                 K = 0;
                 var c = $b[a];
                 c || ($b[a] = c = ac.get(a));
+                // Validate that the looked-up entry is actually a callable function
+                if (typeof c !== "function") {
+                    // Use the existing error logger `q` if available; fall back to console.error
+                    (q || console.error)(`worker: invalid function index ${a}`, c);
+                    return;
+                }
                 a = c(b);
                 0 < K ? (u = a) : bc(a);
             };


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/13](https://github.com/bitbytelabs/Bit/security/code-scanning/13)

General fix: Before invoking a dynamically obtained function, validate that the selector (`a`) is within expected bounds and that the looked-up value is actually a callable function. If the value is invalid, log an error (or otherwise handle it) and avoid calling it. This prevents runtime `TypeError` exceptions and mitigates the impact of untrusted inputs.

Best concrete fix for this code: Hardening `Na` where the untrusted data ends up being used. We can:

1. Keep the `$b[a]` cache pattern as-is.
2. After the cache/lookup (`c || ($b[a] = c = ac.get(a));`), validate:
   - `typeof c === "function"`.
   - Optionally, that `a` is a non-negative integer and that `ac` actually contains that entry (`ac.has?.(a)` if available).
3. If validation fails, log an error using the existing error logger `q` (or `console.error` as fallback), and **return early** without calling `c(b)`.
4. Otherwise, proceed with `a = c(b);` as before.

This preserves behavior for all valid calls but prevents dynamic invocation of non-functions and stops unhandled exceptions from tainted indices. The changes are localized to `Na` (lines 415–421) in `app/assets/engines/lila-stockfish/sf171-79.js`; no new imports or external libraries are required.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
