### PR TITLE
Potential fix for code scanning alert no. 8: Incomplete string escaping or encoding

### DIFF
--- a/assets/libraries/chessgroundx/util.js
+++ b/assets/libraries/chessgroundx/util.js
@@ -15,7 +15,7 @@ export function allPos(bd) {
 export const pos2key = (pos) => (cg.files[pos[0]] + cg.ranks[pos[1]]);
 export const key2pos = (k) => [k.charCodeAt(0) - 97, k.charCodeAt(1) - 49];
 export function roleOf(letter) {
-    return (letter.replace('+', 'p').replace('*', '_').replace('@', '').toLowerCase() + '-piece');
+    return (letter.replace(/\+/g, 'p').replace(/\*/g, '_').replace(/@/g, '').toLowerCase() + '-piece');
 }
 export function letterOf(role, uppercase = false) {
     const letterPart = role.slice(0, role.indexOf('-'));


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/8](https://github.com/bitbytelabs/Bit/security/code-scanning/8)

In general, to fix this kind of issue, every occurrence of naive `str.replace('x', 'y')` used for sanitization or normalization should be converted to a form that replaces all occurrences—either by using a regular expression with the `g` flag (for built-in behavior) or by using a well-tested sanitization/escaping library.

For this specific case, the best fix is to change the sequence of `.replace` calls in `roleOf` to use global regular expressions, ensuring all occurrences of the characters are transformed. That means changing:
- `letter.replace('+', 'p')` to `letter.replace(/\+/g, 'p')`
- `.replace('*', '_')` to `.replace(/\*/g, '_')`
- `.replace('@', '')` to `.replace(/@/g, '')`

No additional imports or helper methods are needed; the changes are local to the `roleOf` function in `assets/libraries/chessgroundx/util.js`, around line 18. This preserves the original intent (mapping symbols to internal role letters, stripping `@`, lowercasing, and appending `-piece`) while correctly handling strings with multiple occurrences of these characters.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
