### PR TITLE
Potential fix for code scanning alert no. 11: Unvalidated dynamic method call

### DIFF
--- a/app/assets/engines/lila-stockfish/sf16-7.js
+++ b/app/assets/engines/lila-stockfish/sf16-7.js
@@ -422,6 +422,10 @@ var Sf167Web = (() => {
                 K = 0;
                 var c = Zb[a];
                 c || (Zb[a] = c = $b.get(a));
+                if (typeof c !== "function") {
+                    q && q(`worker: invalid handler for index ${a}`);
+                    return;
+                }
                 a = c(b);
                 0 < K ? (u = a) : ac(a);
             };


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/11](https://github.com/bitbytelabs/Bit/security/code-scanning/11)

In general, to fix unvalidated dynamic method calls, you must ensure that the value you are about to invoke is (1) present and (2) actually a function before calling it. If the value comes from a user-controllable index or name, guard the lookup with appropriate validation (such as a whitelist, range check, or `hasOwnProperty`/`Map.prototype.has`) and fall back to an error path instead of blindly calling it.

In this specific case, the vulnerable point is inside the `Na` function at lines 421–427:

```js
421:             Na = (a, b) => {
422:                 K = 0;
423:                 var c = Zb[a];
424:                 c || (Zb[a] = c = $b.get(a));
425:                 a = c(b);
426:                 0 < K ? (u = a) : ac(a);
427:             };
```

Here, `a` is an index influenced by data flowing from incoming messages, and `c` is either `Zb[a]` or `$b.get(a)`. The code assumes `c` is a callable function and invokes it. To fix this without altering intended behavior:

1. After resolving `c`, check that it is a function: `if (typeof c !== 'function') { /* handle error */ }`.
2. If it is not a function, log or report the problem using the existing error reporting mechanism (`q` is already used to log worker errors elsewhere), optionally call `Pa()` (as done in the catch handler at lines 167–168) to perform any cleanup, and then either return early or throw a controlled error. Returning early is safer in a compiled runtime as it avoids unexpected control-flow changes.
3. Only proceed to `a = c(b);` when `c` is known to be a function.

No new imports or external libraries are needed; we just add a `typeof` check and an error path. The rest of the file and environment are left untouched.

Concretely, in `app/assets/engines/lila-stockfish/sf16-7.js`, modify the body of `Na` to validate `c` before invoking it, e.g.:

```js
Na = (a, b) => {
    K = 0;
    var c = Zb[a];
    c || (Zb[a] = c = $b.get(a));
    if (typeof c !== "function") {
        q && q(`worker: invalid handler index ${a}`);
        return;
    }
    a = c(b);
    0 < K ? (u = a) : ac(a);
};
```

If you prefer to be closer to existing error handling, you could additionally call `Pa()` before returning. This fix ensures that even if an attacker (or a corrupted message) causes `a` to reference a non-function, the code will not attempt to invoke it and will not throw a `TypeError`, thereby addressing all alert variants that target this call site.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
