### PR TITLE
Potential fix for code scanning alert no. 10: Unvalidated dynamic method call

### DIFF
--- a/app/assets/engines/lila-stockfish/fsf14.js
+++ b/app/assets/engines/lila-stockfish/fsf14.js
@@ -187,7 +187,12 @@ var Fsf14Web = (() => {
                         Ma(d.ia);
                         Ia ||= !0;
                         try {
-                            Na(d.eb, d.Ba);
+                            // Validate entry point index before invoking Na
+                            if (typeof d.eb !== "number" || !Number.isFinite(d.eb)) {
+                                q && q("worker: received invalid entry index for 'run' command");
+                            } else {
+                                Na(d.eb, d.Ba);
+                            }
                         } catch (f) {
                             if ("unwind" != f) throw f;
                         }
@@ -451,11 +456,25 @@ var Fsf14Web = (() => {
             Zb = [],
             $b,
             Na = (a, b) => {
+                // Reset unwind flag
                 K = 0;
+                // Ensure the index used to look up the handler is a valid non-negative integer
+                if (typeof a !== "number" || !Number.isFinite(a) || a < 0 || (a | 0) !== a) {
+                    q && q && q("worker: refusing to call handler with invalid index " + String(a));
+                    return;
+                }
                 var c = Zb[a];
-                c || (Zb[a] = c = $b.get(a));
-                a = c(b);
-                0 < K ? (u = a) : ac(a);
+                if (!c) {
+                    // Lazily populate from the backing map, if present
+                    c = $b && typeof $b.get === "function" ? $b.get(a) : void 0;
+                    Zb[a] = c;
+                }
+                if (typeof c !== "function") {
+                    q && q && q("worker: no callable handler found for index " + String(a));
+                    return;
+                }
+                var result = c(b);
+                0 < K ? (u = result) : ac(result);
             };
         function bc(a, b, c, d) {
             return l ? L(2, 1, a, b, c, d) : cb(a, b, c, d);


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/10](https://github.com/bitbytelabs/Bit/security/code-scanning/10)

In general, the problem is that `Na` uses a user-controlled value (`a`, originating from `d.eb` in the message) to select and invoke a function from a dispatch table (`$b` with cache `Zb`) without validation. The fix is to validate that the index is of the expected type/range and that the resolved entry is actually a function before calling it. If the validation fails, we should log and abort that invocation instead of throwing a `TypeError` or calling an unintended function.

Concretely, the best minimal fix here is:

1. Add validation around the call to `Na` in the message handler `b`, ensuring `d.eb` is a finite non‑negative number and within the bounds of what `$b` can service (insofar as we can cheaply check that).
2. Strengthen `Na` itself so it:
   - Returns early with an error log if `a` is not a finite non‑negative integer.
   - Retrieves the handler function from `Zb[a]` or `$b.get(a)` but then verifies that the result is a function before invoking it.
   - If no valid function is found, logs the situation via `q` (the existing error logger) instead of calling it.

We must do this using only the provided snippet, so we will:

- Modify the `"run"` branch in function `b` around lines 184–193 to guard the call to `Na(d.eb, d.Ba)` with basic type checks.
- Strengthen the body of `Na` around lines 453–458 with additional checks and logging, using the existing `q` function for error reporting.

This avoids changing semantics for valid inputs while preventing unvalidated dynamic dispatch and catching malformed data early.

---


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
