### PR TITLE
Potential fix for code scanning alert no. 17: Uncontrolled data used in path expression

### DIFF
--- a/app/assets/engines/fairy-stockfish-nnue.wasm/uci.js
+++ b/app/assets/engines/fairy-stockfish-nnue.wasm/uci.js
@@ -1,9 +1,11 @@
 const process = require("process");
 const fs = require("fs");
 const readline = require("readline");
+const path = require("path");
 const Stockfish = require("./stockfish.js");
 
 const UCI_NNUE_FILE = process.env.UCI_NNUE_FILE;
+const NNUE_ROOT = process.cwd();
 
 async function runRepl(stockfish) {
   const iface = readline.createInterface({ input: process.stdin });
@@ -20,7 +22,11 @@ async function main(argv) {
   const stockfish = await Stockfish();
   const FS = stockfish.FS;
   if (UCI_NNUE_FILE) {
-    const buffer = await fs.promises.readFile(UCI_NNUE_FILE);
+    const resolvedPath = path.resolve(NNUE_ROOT, UCI_NNUE_FILE);
+    if (!resolvedPath.startsWith(NNUE_ROOT + path.sep) && resolvedPath !== NNUE_ROOT) {
+      throw new Error("UCI_NNUE_FILE path is outside of allowed root directory");
+    }
+    const buffer = await fs.promises.readFile(resolvedPath);
     const filename = "/" + UCI_NNUE_FILE.replace(/^.*[\\\/]/, "");
     FS.writeFile(filename, buffer);
     stockfish.postMessage(`setoption name EvalFile value ${filename}`);


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/17](https://github.com/bitbytelabs/Bit/security/code-scanning/17)

In general, to fix uncontrolled file path usage you should constrain the file location to a known safe directory and/or validate the path before using it. A simple and robust pattern is: define a fixed root directory for NNUE files, normalize the requested path against this root using `path.resolve`, and then ensure that the resulting path still lies within that root (starts with the root path). If the check fails, skip loading the file or fail with a clear error instead of reading an arbitrary path.

For this snippet, the least intrusive fix is:

1. Introduce Node’s built‑in `path` module via `require("path")`.
2. Define a constant safe root directory for NNUE files (for example, from another env variable like `UCI_NNUE_DIR` with a default, or a hard‑coded relative directory). Since we must not assume anything outside the snippet, we will define a local constant such as `const NNUE_ROOT = process.cwd();` (project root) and then resolve the env-specified file name relative to this root.
3. Before reading, compute `const resolvedPath = path.resolve(NNUE_ROOT, UCI_NNUE_FILE);` and verify that `resolvedPath` starts with `NNUE_ROOT + path.sep` (or equals `NNUE_ROOT`) to ensure it doesn’t escape the root via `..` or similar constructs.
4. Only call `fs.promises.readFile` on the validated `resolvedPath`. The rest of the logic (deriving the in‑memory filename and setting the Stockfish option) remains unchanged, because it already strips directory components from the env value for the internal filename.

Concretely in `app/assets/engines/fairy-stockfish-nnue.wasm/uci.js`: add an import for `path` near the top, add a root constant after the `UCI_NNUE_FILE` constant, and replace the body of the `if (UCI_NNUE_FILE)` block (lines 22–27) with logic that resolves and checks the path before reading. No new external libraries are required; we only use Node’s standard `path` module.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
