### PR TITLE
Potential fix for code scanning alert no. 1: Replacement of a substring with itself

### DIFF
--- a/assets/libraries/chess.js/chess.js
+++ b/assets/libraries/chess.js/chess.js
@@ -1608,7 +1608,9 @@ export const Chess = function (fen) {
           : false
 
       function mask(str) {
-        return str.replace(/\\/g, '\\')
+        // Escape backslashes so the resulting string can be safely embedded
+        // into a RegExp constructor.
+        return str.replace(/\\/g, '\\\\')
       }
 
       function has_keys(object) {


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/1](https://github.com/bitbytelabs/Bit/security/code-scanning/1)

In general, to fix this type of issue you must change the replacement so that the substring is actually transformed, usually by adding an extra backslash or choosing another appropriate replacement string. Here, `mask` should escape backslashes in `str` so that when `str` is interpolated into a regular expression, the regex sees literal backslashes instead of control sequences.

The single best fix with minimal impact is to change `mask` so it doubles backslashes: replacing each `\` with `\\`. This aligns with its use in `header.split(new RegExp(mask(newline_char)))`, allowing both the default regex fragment (`'\r?\n'`) and any user‑supplied value that might contain backslashes to be safely embedded. Concretely, in `assets/libraries/chess.js/chess.js` around line 1610, update the `mask` function’s `replace` call from `str.replace(/\\/g, '\\')` to `str.replace(/\\/g, '\\\\')`. No new imports or helpers are needed.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
