### PR TITLE
fix: repair GitHub Actions workflow versions

### DIFF
--- a/.github/workflows/autofix.yml
+++ b/.github/workflows/autofix.yml
@@ -196,7 +196,7 @@ jobs:
           if [[ -n $(git status --porcelain) ]]; then
             git checkout -b security/fix-remote-property
             git add .
-            git commit -m "Fix js/remote-property-injection"
+            git commit -m "fix: js/remote-property-injection"
             git push origin security/fix-remote-property
           else
             echo "No changes to commit."
@@ -206,7 +206,7 @@ jobs:
         uses: peter-evans/create-pull-request@v6
         with:
           branch: security/fix-remote-property
-          title: "Fix js/remote-property-injection"
+          title: "fix: js/remote-property-injection"
           body: |
             Automatically fixes CodeQL rule:
             js/remote-property-injection

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -14,12 +14,12 @@ jobs:
 
     steps:
       - name: Checkout repo
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0
 
       - name: Setup Node
-        uses: actions/setup-node@v6
+        uses: actions/setup-node@v4
         with:
           node-version: 24
 

--- a/.github/workflows/summary.yml
+++ b/.github/workflows/summary.yml
@@ -14,7 +14,7 @@ jobs:
 
     steps:
       - name: Checkout repository
-        uses: actions/checkout@v6
+        uses: actions/checkout@v4
 
       - name: Run AI inference
         id: inference


### PR DESCRIPTION
### Motivation

- Fix GitHub Actions workflow errors caused by unsupported action versions and non-conventional auto-generated commit/PR titles to ensure CI workflows run and semantic-release rules are respected.

### Description

- Downgraded `actions/checkout@v6` to `actions/checkout@v4` in `release.yml` and `summary.yml` to use a supported action version.
- Downgraded `actions/setup-node@v6` to `actions/setup-node@v4` in `release.yml` to align with the runner environment.
- Updated the autofix workflow to use a conventional commit-style title/message by changing the generated commit and PR title to `fix: js/remote-property-injection` in `.github/workflows/autofix.yml`.
- Changes span `.github/workflows/release.yml`, `.github/workflows/summary.yml`, and `.github/workflows/autofix.yml` and are limited to workflow metadata and strings.

### Testing

- Ran `actionlint` against `.github/workflows/*.yml` while ignoring the current unknown `models` permission warning and confirmed no other linter errors were reported.
- Executed a Python scan across all HTML files to verify the Firebase analytics snippet appears exactly once per page and found no missing or duplicate analytics blocks.
- Attempted to run `act -n` to simulate GitHub Actions locally but it failed because `act` is not installed in the environment.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69930e02bb4c8332afced20f008acd1c)