### PR TITLE
Potential fix for code scanning alert no. 76: Uncontrolled data used in path expression

### DIFF
--- a/app/assets/engines/fairy-stockfish-nnue.wasm/uci.js
+++ b/app/assets/engines/fairy-stockfish-nnue.wasm/uci.js
@@ -5,7 +5,7 @@ const path = require("path");
 const Stockfish = require("./stockfish.js");
 
 const UCI_NNUE_FILE = process.env.UCI_NNUE_FILE;
-const NNUE_ROOT = process.cwd();
+const NNUE_ROOT = fs.realpathSync(process.cwd());
 
 async function runRepl(stockfish) {
   const iface = readline.createInterface({ input: process.stdin });
@@ -23,10 +23,14 @@ async function main(argv) {
   const FS = stockfish.FS;
   if (UCI_NNUE_FILE) {
     const resolvedPath = path.resolve(NNUE_ROOT, UCI_NNUE_FILE);
-    if (!resolvedPath.startsWith(NNUE_ROOT + path.sep) && resolvedPath !== NNUE_ROOT) {
+    const realResolvedPath = fs.realpathSync(resolvedPath);
+    if (
+      realResolvedPath !== NNUE_ROOT &&
+      !realResolvedPath.startsWith(NNUE_ROOT + path.sep)
+    ) {
       throw new Error("UCI_NNUE_FILE path is outside of allowed root directory");
     }
-    const buffer = await fs.promises.readFile(resolvedPath);
+    const buffer = await fs.promises.readFile(realResolvedPath);
     const filename = "/" + UCI_NNUE_FILE.replace(/^.*[\\\/]/, "");
     FS.writeFile(filename, buffer);
     stockfish.postMessage(`setoption name EvalFile value ${filename}`);


### PR DESCRIPTION
Potential fix for [https://github.com/bitbytelabs/Bit/security/code-scanning/76](https://github.com/bitbytelabs/Bit/security/code-scanning/76)

To fix the problem you should ensure that any path derived from `UCI_NNUE_FILE` is both normalized and verified to be inside the intended root directory, using the same canonicalization mechanisms the OS uses (i.e., resolving symlinks), before it is passed to `fs.promises.readFile`. This matches the “root folder” mitigation described in the background.

The best minimal change, without altering existing functionality, is:
- Canonicalize `NNUE_ROOT` to a real (symlink-resolved) absolute path once.
- Resolve `UCI_NNUE_FILE` against that canonical root.
- Canonicalize the resolved path using `fs.realpathSync`.
- Check that the canonical resolved path is within the canonical root using a robust prefix check that accounts for separator boundaries.
- Only then read the file.

Concretely in `app/assets/engines/fairy-stockfish-nnue.wasm/uci.js`:

1. Replace `const NNUE_ROOT = process.cwd();` with a canonical, normalized absolute root, e.g.:
   ```js
   const NNUE_ROOT = fs.realpathSync(process.cwd());
   ```
   This ties the “root” concept to a canonical path (no symlinks or `.`/`..` segments).

2. In the `if (UCI_NNUE_FILE)` block:
   - After computing `resolvedPath = path.resolve(NNUE_ROOT, UCI_NNUE_FILE);`, call `fs.realpathSync(resolvedPath)` and use the result for validation and reading.
   - Replace the current `startsWith` check with one that uses the canonical root and ensures that either the path equals the root or starts with `root + path.sep`. Use this canonical path for `readFile`.

No new external libraries are required; Node’s built-in `fs` and `path` modules are already imported and sufficient.


_Suggested fixes powered by Copilot Autofix. Review carefully before merging._
