### PR TITLE
fix: align board overlay with its container

### DIFF
--- a/assets/libraries/UniversalBoardDrawer/UniversalBoardDrawer.js
+++ b/assets/libraries/UniversalBoardDrawer/UniversalBoardDrawer.js
@@ -438,13 +438,14 @@ class UniversalBoardDrawer {
 
     updateDimensions() {
         const boardRect = this.boardElem.getBoundingClientRect(),
-              bodyRect = this.document.body.getBoundingClientRect(); // https://stackoverflow.com/a/62106310
+              bodyRect = this.document.body.getBoundingClientRect(), // https://stackoverflow.com/a/62106310
+              parentRect = this.parentElem?.getBoundingClientRect?.() || bodyRect;
 
         let boardWidth = boardRect.width,
             boardHeight = boardRect.height;
 
-        let boardPositionTop = boardRect.top - bodyRect.top,
-            boardPositionLeft = boardRect.left - (this.ignoreBodyRectLeft ? 0 : bodyRect.left);
+        let boardPositionTop = boardRect.top - parentRect.top,
+            boardPositionLeft = boardRect.left - (this.ignoreBodyRectLeft ? 0 : parentRect.left);
 
         if(this.adjustSizeByDimensions) {
 


### PR DESCRIPTION
### Motivation
- The board overlay could be misaligned when the drawings container is not the document body, so the overlay must compute offsets relative to the configured parent element.

### Description
- Update `updateDimensions()` in `assets/libraries/UniversalBoardDrawer/UniversalBoardDrawer.js` to compute `parentRect = this.parentElem?.getBoundingClientRect?.() || bodyRect` and use `parentRect` as the positioning baseline instead of always using `document.body` while preserving the existing fallback and `ignoreBodyRectLeft` behavior.

### Testing
- Ran `node --check assets/libraries/UniversalBoardDrawer/UniversalBoardDrawer.js` and it succeeded.
- Served the app with `python3 -m http.server --directory /workspace/Bit 4173`, opened `http://localhost:4173/app/index.html` and captured a Playwright screenshot for visual verification which completed successfully.

------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_69968dbddbdc833288af480d4035d563)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Improved board positioning calculations to reference parent element bounds instead of document body, enabling more accurate placement in nested layouts.

* **Style**
  * Minor formatting updates to code structure.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->